### PR TITLE
Version 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ to a position, which return a list of objects (typically, positions).
 
  - `move` (or `m` for short): performs as forward move.
 
+ - `legal`: analyzes the legality of the position and its history.
+   This may label the position as:
+     - *illegal* (FIDE illegal), when the position is unreachable from
+        the starting position via a sequence of legal moves (that is,
+        not considering FIDE Article 5.2.2 about "dead positions").
+     - *zombie*, when it is FIDE legal, but all possible legal retractions
+        are from dead positions.
+     - No label on if FIDE legal and non-zombie.
+
+   This command also analyzes whether a position is alive/dead when the
+   position is the result of a retraction or it is part of a longer sequence
+   of moves, possibly labeling the position as "dead".
+
+ - `DP` : labels the position as "DP" (dead position) or "alive".
+
  - `flip`: flips the turn. This also resets the halfmove clock,
     and the en-passant flags to `?` (but preserves castling rights).
     The position(s) after a flip become the "game array", i.e., they
@@ -57,16 +72,16 @@ to a position, which return a list of objects (typically, positions).
 
  - `ep` : returns the en-passant privileges of the given position.
 
- - `DP` : labels the position as "DP" (dead position) or "alive".
-
- - A solve command (which stops the potential `>>=` chain). The following solve
-   commands are supported:
+ - A solve command. The following solve commands are supported:
      - `#[0-9]+[.5]?`: *forced mate* in the given number of moves.
      - `h#[0-9]+[.5]?`: *help mate* in the given number of moves.
      - `h=[0-9]+[.5]?`: *help stalemate* in the given number of moves.
      - `hdp[0-9]+[.5]?`: *help dead position* in the given number of moves.
      - `h~=[0-9]+[.5]?`: *help draw* (stalemate or dead) in the given number of
         moves.
+
+   This transforms the position into the final position of every solution.
+   (The monadic chain `>>=` may continue from those.)
 
    A solve command can be succeded (after a blank space) with a piece type in
    round brackets (to choose from `p`, `n`, `b`, `r`, `q`, `k`).
@@ -81,11 +96,11 @@ For example:
 ```
 // Julio Sunyer, 1923 (The Chess Amateur)
 >>> 4k3/8/8/7K/8/8/8/8 b - - >>= r >>= r >>= h#1
-g6xRh5 h8xQh5 then e8g8 h5h7#
+↶g6xRh5 ↶h8xQh5 e8g8 h5h7# 5rk1/8/6K1/7Q/8/8/8/8 w - - 1 2
 nsols 1
 
 // Andrew Buchanan, 2001 (1 Retros mailing list 24th Jan)
->>> k7/8/2K5/8/8/8/8/8 ? >>= turn
+>>> k7/8/2K5/8/8/8/8/8 ? >>= legal >>= turn
 b
 nsols 1
 ```
@@ -96,63 +111,57 @@ nsols 1
   well-formed positions (exactly one king per side, no pawns on 1st or 8th rank,
   etc) even if they are illegal.
   Furthermore, in virtue of FIDE Article 5.2.2, all positions preceeding a
-  **dead** position should be **alive**.
-  Our retractor still displays those that are dead, but it labels them.
+  *dead* position should be *alive*.
+  Our retractor still displays those that are dead, but it labels them if
+  the command `legal` is used.
 
 - We perform minimal legality checks on a position, by checking whether it
-  admits at least an alive retraction.
-  Positions that are identified to be illegal with this simple check are labeled
-  as so and displayed.
+  admits at least a retraction.
+  This means at the moment our legality analysis is a semi-decision procedure.
+  If a position is labeled as "illegal", it is definitely illegal.
+  However, non-labeled positions could be legal and escape our current logic.
+  *We are working on making this legality check more complete*.
 
 - Even though we display illegal and dead (retracted from dead) positions,
   they do not carry on to the next command. For example, 6 possible well-formed
   retractions are shown after the following command:
   ```
-  >>> 8/8/8/8/2Q5/k7/1pP5/K7 w - - >>= r
-  8/8/8/8/2Q5/kp6/2P5/K7 b - - ? 0 b3b2
-  8/8/8/8/2Q5/k1p5/1PP5/K7 b - - ? 0 (illegal) c3xPb2
-  8/8/8/8/2Q5/k1p5/1QP5/K7 b - - ? 0 (dead) c3xQb2
-  8/8/8/8/2Q5/k1p5/1RP5/K7 b - - ? 0 (dead) c3xRb2
-  8/8/8/8/2Q5/k1p5/1BP5/K7 b - - ? 0 (dead) c3xBb2
-  8/8/8/8/2Q5/k1p5/1NP5/K7 b - - ? 0 (dead) c3xNb2
+  >>> 8/8/8/8/2Q5/k7/1pP5/K7 w - - >>= r >>= legal
+  ↶b3b2 8/8/8/8/2Q5/kp6/2P5/K7 b - - ? 0
+  ↶c3xPb2 illegal dead 8/8/8/8/2Q5/k1p5/1PP5/K7 b - - ? 0
+  ↶c3xQb2 dead 8/8/8/8/2Q5/k1p5/1QP5/K7 b - - ? 0
+  ↶c3xRb2 dead 8/8/8/8/2Q5/k1p5/1RP5/K7 b - - ? 0
+  ↶c3xBb2 dead 8/8/8/8/2Q5/k1p5/1BP5/K7 b - - ? 0
+  ↶c3xNb2 dead 8/8/8/8/2Q5/k1p5/1NP5/K7 b - - ? 0
   nsols 1
   ```
   However, 5 of them were labeled as either illegal or dead.
   If we then apply another command, e.g. `>>= h=1.5`, these 5 will not be
   considered in the analysis, only the very first one
-  `8/8/8/8/2Q5/kp6/2P5/K7 b - - ? 0 b3b2`.
+  `8/8/8/8/2Q5/kp6/2P5/K7 b - - ? 0`.
 
 - In case our dead position subroutine fails to determine whether a position
   is *dead*, the following error message will be raised:
   ```
-  >>> B2b4/8/4k3/8/1p1p1p1p/1PpP1P1P/K1P4b/RB6 b - - 0 1 >>= hdp0
+  >>> B2b4/8/4k3/8/1p1p1p1p/1PpP1P1P/K1P4b/RB6 b - - 0 1 >>= DP
   RuntimeError: CHA failed on B2b4/8/4k3/8/1p1p1p1p/1PpP1P1P/K1P4b/RB6 b - - 0 1
   ```
   In a successful execution, every computation regarding dead positions is
-  *sound* and *correct* in the sense that the tool either finds a helpmate
-  (proving the position is alive) or definitely proves that the position is dead.
+  *sound* in the sense that the tool either finds a helpmate (proving the
+  position is alive) or definitely proves that the position is dead.
 
 - FEN tokens can be unspecified with `?`, in which case, the tool will consider
   all plausible values of that token. For example, the following considers that
   the en-passant flag takes values `-` or `g6`.
   ```
-  >>> 6br/4Bp1k/5P2/5PpK/4B1P1/8/8/8 w - ? ? 100 >>= r
-  6br/4Bppk/5P2/5P1K/4B1P1/8/8/8 b - - ? 99 g7g5
-  nsols 1
+  >>> 6br/4Bp1k/5P2/5PpK/4B1P1/8/8/8 w - ? ? 100
+  6br/4Bp1k/5P2/5PpK/4B1P1/8/8/8 w - - ? 100
+  6br/4Bp1k/5P2/5PpK/4B1P1/8/8/8 w - g6 ? 100
+  nsols 2
   ```
 
 - Not all 6 FEN tokens are necessary. If fewer tokens are specified, the
-  remaining will be filled with `?`. For example:
-  ```
-  >>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= r
-  8/7Q/8/4BB2/2PPkP2/3N1N2/PP2P1P1/4K2R b K - ? 0 e4e3
-  8/7Q/8/4BB2/2PPkP2/3NPN2/PP2P1P1/4K2R b K - ? 0 e4xPe3
-  8/7Q/8/4BB2/2PPkP2/3NQN2/PP2P1P1/4K2R b K - ? 0 (illegal) e4xQe3
-  8/7Q/8/4BB2/2PPkP2/3NRN2/PP2P1P1/4K2R b K - ? 0 (illegal) e4xRe3
-  8/7Q/8/4BB2/2PPkP2/3NBN2/PP2P1P1/4K2R b K - ? 0 e4xBe3
-  8/7Q/8/4BB2/2PPkP2/3NNN2/PP2P1P1/4K2R b K - ? 0 e4xNe3
-  nsols 4
-  ```
+  remaining will be filled with `?`.
 
 - When the halfmove clock is specified, it will be considered in the computation
   of retractions. That is, if it is specified to be `0`, the last move must have
@@ -160,16 +169,23 @@ nsols 1
   retractions will be officer non-captures.
   For example:
   ```
-  >>> k7/8/2K5/8/8/8/8/8 b - - 0 50 >>= r
-  k7/3K4/2p5/8/8/8/8/8 w - - ? 50 d7xPc6
-  k7/3K4/2q5/8/8/8/8/8 w - - ? 50 d7xQc6
-  k7/3K4/2r5/8/8/8/8/8 w - - ? 50 d7xRc6
+  >>> k7/8/2K5/8/8/8/8/8 b - - 0 50 >>= r >>= legal
+  ↶d7xPc6 k7/3K4/2p5/8/8/8/8/8 w - - ? 50
+  ↶d7xQc6 k7/3K4/2q5/8/8/8/8/8 w - - ? 50
+  ↶d7xRc6 k7/3K4/2r5/8/8/8/8/8 w - - ? 50
   ...
   nsols 21
   ```
   but
   ```
-  >>> k7/8/2K5/8/8/8/8/8 b - - 1 50 >>= r
+  >>> k7/8/2K5/8/8/8/8/8 b - - 1 50 >>= r >>= legal
+  ↶d7c6 dead k7/3K4/8/8/8/8/8/8 w - - 0 50
+  ↶d5c6 dead k7/8/8/3K4/8/8/8/8 w - - 0 50
+  ↶b5c6 dead k7/8/8/1K6/8/8/8/8 w - - 0 50
+  ↶c7c6 zombie k7/2K5/8/8/8/8/8/8 w - - 0 50
+  ↶c5c6 dead k7/8/8/2K5/8/8/8/8 w - - 0 50
+  ↶d6c6 dead k7/8/3K4/8/8/8/8/8 w - - 0 50
+  ↶b6c6 zombie k7/8/1K6/8/8/8/8/8 w - - 0 50
   nsols 0
   ```
 
@@ -181,14 +197,14 @@ nsols 1
   term `half-duplex` next to the specification. For example:
   ```
   >>> 8/8/2B5/5Q2/8/4p2P/4k2K/8 w - - >>= h#3 half-duplex
-  f5b1 e2f2 c6h1 e3e2 b1f1 e2f1n#
+  f5b1 e2f2 c6h1 e3e2 b1f1 e2f1n# 8/8/8/8/8/7P/4pk1K/5Q1B b - - 1 3
   nsols 1
   ```
   Furthermore, if the term `duplex` is specified, both WTM and BTM positions
   will be considered.
 
 - For the impatient folk, you can run Deadpos with flag `--fast` to
-  significtly speed-up the analysis of dead positions. This means the analysis
+  significantly speed-up the analysis of dead positions. This means the analysis
   may miss some complicated dead positions and there is no way to know about it.
   Use this flag if you want to find cooks (if they exist, they will probably
   be found with this method) or you are designing a problem. However, in order
@@ -197,7 +213,6 @@ nsols 1
 
 - You can disable the progress bar with `--no-progress-bar`.
 
-- You can use flag `--verbose` to get a more detailed output.
 
 ## Feedback
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,11 +25,11 @@ get-retractor:
 	cd ../lib/retractor && eval `(opam env)` && dune build
 
 test:
-	cat ../test/test-vectors.txt | python3 deadpos.py --verbose --no-progress-bar > /tmp/test-vectors.out
+	cat ../test/test-vectors.txt | python3 deadpos.py --no-progress-bar > /tmp/test-vectors.out
 	diff ../test/test-vectors.out /tmp/test-vectors.out
 
 pdb-tests:
-	cat ../test/PDB.txt | grep -v Slow | python3 deadpos.py --verbose --no-progress-bar > /tmp/PDB.out
+	cat ../test/PDB.txt | grep -v Slow | python3 deadpos.py --no-progress-bar > /tmp/PDB.out
 	diff ../test/PDB.out /tmp/PDB.out
 
 promote-tests:

--- a/test/PDB.out
+++ b/test/PDB.out
@@ -1,389 +1,416 @@
-Deadpos Analyzer version 2.2
+Deadpos Analyzer version 2.3
 // deadpos problems from PDB (https://pdb.dieschwalbe.de):
 // cpluscomment='deadpos'
 // 3 long cooked ones are commented out: 31, 32, 33
 // 1 - P0002478 Mrs. W. J. Baird 1 British Chess Magazine, p. 491, 12/1903
 // 2 - P0002479 Frederick Baird 1877 Morning Post 21/02/1910
 // 3 - P0005387 Nikita M. Plaksin 6557 feenschach 109 11/1993
->>> 8/8/8/8/K7/8/b7/kB6 b >>= r >>= h=0.5
-a3xPa4 then b1a2 stalemate                                                      
-nsols 1                                                                        
+>>> 8/8/8/8/K7/8/b7/kB6 b >>= r >>= h=0.5 >>= legal
+↶b3a4 illegal dead b1a2 stalemate 8/8/8/8/8/1K6/B7/k7 b - - 0 1                 
+↶a3a4 dead b1a2 stalemate 8/8/8/8/8/K7/B7/k7 b - - 0 1                          
+↶a3xPa4 b1a2 stalemate 8/8/8/8/p7/K7/B7/k7 b - - 0 1                            
+nsols 1
+                                                                       
 // 4 - P1001034 Andrew Buchanan 1 Retros mailing list 24/01/2001
->>> k7/8/2K5/8/8/8/8/8 ? >>= turn
+>>> k7/8/2K5/8/8/8/8/8 ? >>= legal >>= turn
 b
-nsols 1                                                                        
->>> k7/8/2K5/8/8/8/8/8 ? >>= r
-8/k7/2K5/8/8/8/8/8 b - - ? 0 (dead) a7a8
-1k6/8/2K5/8/8/8/8/8 b - - ? 0 (dead) b8a8
-Q7/k7/2K5/8/8/8/8/8 b - - ? 0 (dead) a7xQa8
-R7/k7/2K5/8/8/8/8/8 b - - ? 0 (dead) a7xRa8
-B7/k7/2K5/8/8/8/8/8 b - - ? 0 (dead) a7xBa8
-N7/k7/2K5/8/8/8/8/8 b - - ? 0 (dead) a7xNa8
-Qk6/8/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xQa8
-Rk6/8/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xRa8
-Bk6/8/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xBa8
-Nk6/8/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xNa8
-k7/3K4/8/8/8/8/8/8 w - - ? 1 (dead) d7c6
-k7/8/8/3K4/8/8/8/8 w - - ? 1 (dead) d5c6
-k7/8/8/1K6/8/8/8/8 w - - ? 1 (dead) b5c6
-k7/2K5/8/8/8/8/8/8 w - - ? 1 (illegal) c7c6
-k7/8/8/2K5/8/8/8/8 w - - ? 1 (dead) c5c6
-k7/8/3K4/8/8/8/8/8 w - - ? 1 (dead) d6c6
-k7/8/1K6/8/8/8/8/8 w - - ? 1 (illegal) b6c6
-k7/3K4/2p5/8/8/8/8/8 w - - ? 1 d7xPc6
-k7/3K4/2q5/8/8/8/8/8 w - - ? 1 d7xQc6
-k7/3K4/2r5/8/8/8/8/8 w - - ? 1 d7xRc6
-k7/3K4/2b5/8/8/8/8/8 w - - ? 1 (dead) d7xBc6
-k7/3K4/2n5/8/8/8/8/8 w - - ? 1 (dead) d7xNc6
-k7/8/2p5/3K4/8/8/8/8 w - - ? 1 d5xPc6
-k7/8/2q5/3K4/8/8/8/8 w - - ? 1 d5xQc6
-k7/8/2r5/3K4/8/8/8/8 w - - ? 1 d5xRc6
-k7/8/2b5/3K4/8/8/8/8 w - - ? 1 (dead) d5xBc6
-k7/8/2n5/3K4/8/8/8/8 w - - ? 1 (dead) d5xNc6
-k7/8/2p5/1K6/8/8/8/8 w - - ? 1 b5xPc6
-k7/8/2q5/1K6/8/8/8/8 w - - ? 1 b5xQc6
-k7/8/2r5/1K6/8/8/8/8 w - - ? 1 b5xRc6
-k7/8/2b5/1K6/8/8/8/8 w - - ? 1 (dead) b5xBc6
-k7/8/2n5/1K6/8/8/8/8 w - - ? 1 (dead) b5xNc6
-k7/2K5/2p5/8/8/8/8/8 w - - ? 1 c7xPc6
-k7/2K5/2q5/8/8/8/8/8 w - - ? 1 c7xQc6
-k7/2K5/2r5/8/8/8/8/8 w - - ? 1 c7xRc6
-k7/2K5/2b5/8/8/8/8/8 w - - ? 1 (dead) c7xBc6
-k7/2K5/2n5/8/8/8/8/8 w - - ? 1 (dead) c7xNc6
-k7/8/2p5/2K5/8/8/8/8 w - - ? 1 c5xPc6
-k7/8/2q5/2K5/8/8/8/8 w - - ? 1 c5xQc6
-k7/8/2r5/2K5/8/8/8/8 w - - ? 1 c5xRc6
-k7/8/2b5/2K5/8/8/8/8 w - - ? 1 (dead) c5xBc6
-k7/8/2n5/2K5/8/8/8/8 w - - ? 1 (dead) c5xNc6
-k7/8/2pK4/8/8/8/8/8 w - - ? 1 d6xPc6
-k7/8/2qK4/8/8/8/8/8 w - - ? 1 d6xQc6
-k7/8/2rK4/8/8/8/8/8 w - - ? 1 d6xRc6
-k7/8/2bK4/8/8/8/8/8 w - - ? 1 (dead) d6xBc6
-k7/8/2nK4/8/8/8/8/8 w - - ? 1 (dead) d6xNc6
-k7/8/1Kp5/8/8/8/8/8 w - - ? 1 b6xPc6
-k7/8/1Kq5/8/8/8/8/8 w - - ? 1 b6xQc6
-k7/8/1Kr5/8/8/8/8/8 w - - ? 1 b6xRc6
-k7/8/1Kb5/8/8/8/8/8 w - - ? 1 (dead) b6xBc6
-k7/8/1Kn5/8/8/8/8/8 w - - ? 1 (dead) b6xNc6
-nsols 21                                                                        
+nsols 1
+                                                                       
+>>> k7/8/2K5/8/8/8/8/8 ? >>= r >>= legal
+↶a7a8 dead 8/k7/2K5/8/8/8/8/8 b - - ? 0                                         
+↶b8a8 dead 1k6/8/2K5/8/8/8/8/8 b - - ? 0                                        
+↶a7xQa8 dead Q7/k7/2K5/8/8/8/8/8 b - - ? 0                                      
+↶a7xRa8 dead R7/k7/2K5/8/8/8/8/8 b - - ? 0                                      
+↶a7xBa8 dead B7/k7/2K5/8/8/8/8/8 b - - ? 0                                      
+↶a7xNa8 dead N7/k7/2K5/8/8/8/8/8 b - - ? 0                                      
+↶b8xQa8 dead Qk6/8/2K5/8/8/8/8/8 b - - ? 0                                      
+↶b8xRa8 dead Rk6/8/2K5/8/8/8/8/8 b - - ? 0                                      
+↶b8xBa8 dead Bk6/8/2K5/8/8/8/8/8 b - - ? 0                                      
+↶b8xNa8 dead Nk6/8/2K5/8/8/8/8/8 b - - ? 0                                      
+↶d7c6 dead k7/3K4/8/8/8/8/8/8 w - - ? 1                                         
+↶d5c6 dead k7/8/8/3K4/8/8/8/8 w - - ? 1                                         
+↶b5c6 dead k7/8/8/1K6/8/8/8/8 w - - ? 1                                         
+↶c7c6 zombie k7/2K5/8/8/8/8/8/8 w - - ? 1                                       
+↶c5c6 dead k7/8/8/2K5/8/8/8/8 w - - ? 1                                         
+↶d6c6 dead k7/8/3K4/8/8/8/8/8 w - - ? 1                                         
+↶b6c6 zombie k7/8/1K6/8/8/8/8/8 w - - ? 1                                       
+↶d7xPc6 k7/3K4/2p5/8/8/8/8/8 w - - ? 1                                          
+↶d7xQc6 k7/3K4/2q5/8/8/8/8/8 w - - ? 1                                          
+↶d7xRc6 k7/3K4/2r5/8/8/8/8/8 w - - ? 1                                          
+↶d7xBc6 dead k7/3K4/2b5/8/8/8/8/8 w - - ? 1                                     
+↶d7xNc6 dead k7/3K4/2n5/8/8/8/8/8 w - - ? 1                                     
+↶d5xPc6 k7/8/2p5/3K4/8/8/8/8 w - - ? 1                                          
+↶d5xQc6 k7/8/2q5/3K4/8/8/8/8 w - - ? 1                                          
+↶d5xRc6 k7/8/2r5/3K4/8/8/8/8 w - - ? 1                                          
+↶d5xBc6 dead k7/8/2b5/3K4/8/8/8/8 w - - ? 1                                     
+↶d5xNc6 dead k7/8/2n5/3K4/8/8/8/8 w - - ? 1                                     
+↶b5xPc6 k7/8/2p5/1K6/8/8/8/8 w - - ? 1                                          
+↶b5xQc6 k7/8/2q5/1K6/8/8/8/8 w - - ? 1                                          
+↶b5xRc6 k7/8/2r5/1K6/8/8/8/8 w - - ? 1                                          
+↶b5xBc6 dead k7/8/2b5/1K6/8/8/8/8 w - - ? 1                                     
+↶b5xNc6 dead k7/8/2n5/1K6/8/8/8/8 w - - ? 1                                     
+↶c7xPc6 k7/2K5/2p5/8/8/8/8/8 w - - ? 1                                          
+↶c7xQc6 k7/2K5/2q5/8/8/8/8/8 w - - ? 1                                          
+↶c7xRc6 k7/2K5/2r5/8/8/8/8/8 w - - ? 1                                          
+↶c7xBc6 dead k7/2K5/2b5/8/8/8/8/8 w - - ? 1                                     
+↶c7xNc6 dead k7/2K5/2n5/8/8/8/8/8 w - - ? 1                                     
+↶c5xPc6 k7/8/2p5/2K5/8/8/8/8 w - - ? 1                                          
+↶c5xQc6 k7/8/2q5/2K5/8/8/8/8 w - - ? 1                                          
+↶c5xRc6 k7/8/2r5/2K5/8/8/8/8 w - - ? 1                                          
+↶c5xBc6 dead k7/8/2b5/2K5/8/8/8/8 w - - ? 1                                     
+↶c5xNc6 dead k7/8/2n5/2K5/8/8/8/8 w - - ? 1                                     
+↶d6xPc6 k7/8/2pK4/8/8/8/8/8 w - - ? 1                                           
+↶d6xQc6 k7/8/2qK4/8/8/8/8/8 w - - ? 1                                           
+↶d6xRc6 k7/8/2rK4/8/8/8/8/8 w - - ? 1                                           
+↶d6xBc6 dead k7/8/2bK4/8/8/8/8/8 w - - ? 1                                      
+↶d6xNc6 dead k7/8/2nK4/8/8/8/8/8 w - - ? 1                                      
+↶b6xPc6 k7/8/1Kp5/8/8/8/8/8 w - - ? 1                                           
+↶b6xQc6 k7/8/1Kq5/8/8/8/8/8 w - - ? 1                                           
+↶b6xRc6 k7/8/1Kr5/8/8/8/8/8 w - - ? 1                                           
+↶b6xBc6 dead k7/8/1Kb5/8/8/8/8/8 w - - ? 1                                      
+↶b6xNc6 dead k7/8/1Kn5/8/8/8/8/8 w - - ? 1                                      
+nsols 21
+                                                                       
 // 5 - P1001036 Andrew Buchanan 2 Retros mailing list 24/01/2001
->>> k7/N7/2K5/8/8/8/8/8 ? >>= turn
+>>> k7/N7/2K5/8/8/8/8/8 ? >>= legal >>= turn
 b
-nsols 1                                                                        
->>> k7/N7/2K5/8/8/8/8/8 ? >>= r
-1k6/N7/2K5/8/8/8/8/8 b - - ? 0 (dead) b8a8
-Qk6/N7/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xQa8
-Rk6/N7/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xRa8
-Bk6/N7/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xBa8
-Nk6/N7/2K5/8/8/8/8/8 b - - ? 0 (dead) b8xNa8
-k7/N2K4/8/8/8/8/8/8 w - - ? 1 (dead) d7c6
-k7/N7/8/3K4/8/8/8/8 w - - ? 1 (dead) d5c6
-k7/N7/8/1K6/8/8/8/8 w - - ? 1 (dead) b5c6
-k7/N1K5/8/8/8/8/8/8 w - - ? 1 (illegal) c7c6
-k7/N7/8/2K5/8/8/8/8 w - - ? 1 (dead) c5c6
-k7/N7/3K4/8/8/8/8/8 w - - ? 1 (dead) d6c6
-k7/N7/1K6/8/8/8/8/8 w - - ? 1 (illegal) b6c6
-k7/N2K4/2p5/8/8/8/8/8 w - - ? 1 d7xPc6
-k7/N2K4/2q5/8/8/8/8/8 w - - ? 1 d7xQc6
-k7/N2K4/2r5/8/8/8/8/8 w - - ? 1 d7xRc6
-k7/N2K4/2b5/8/8/8/8/8 w - - ? 1 d7xBc6
-k7/N2K4/2n5/8/8/8/8/8 w - - ? 1 d7xNc6
-k7/N7/2p5/3K4/8/8/8/8 w - - ? 1 d5xPc6
-k7/N7/2q5/3K4/8/8/8/8 w - - ? 1 d5xQc6
-k7/N7/2r5/3K4/8/8/8/8 w - - ? 1 d5xRc6
-k7/N7/2b5/3K4/8/8/8/8 w - - ? 1 d5xBc6
-k7/N7/2n5/3K4/8/8/8/8 w - - ? 1 d5xNc6
-k7/N7/2p5/1K6/8/8/8/8 w - - ? 1 b5xPc6
-k7/N7/2q5/1K6/8/8/8/8 w - - ? 1 b5xQc6
-k7/N7/2r5/1K6/8/8/8/8 w - - ? 1 b5xRc6
-k7/N7/2b5/1K6/8/8/8/8 w - - ? 1 b5xBc6
-k7/N7/2n5/1K6/8/8/8/8 w - - ? 1 b5xNc6
-k7/N1K5/2p5/8/8/8/8/8 w - - ? 1 c7xPc6
-k7/N1K5/2q5/8/8/8/8/8 w - - ? 1 c7xQc6
-k7/N1K5/2r5/8/8/8/8/8 w - - ? 1 c7xRc6
-k7/N1K5/2b5/8/8/8/8/8 w - - ? 1 c7xBc6
-k7/N1K5/2n5/8/8/8/8/8 w - - ? 1 c7xNc6
-k7/N7/2p5/2K5/8/8/8/8 w - - ? 1 c5xPc6
-k7/N7/2q5/2K5/8/8/8/8 w - - ? 1 c5xQc6
-k7/N7/2r5/2K5/8/8/8/8 w - - ? 1 c5xRc6
-k7/N7/2b5/2K5/8/8/8/8 w - - ? 1 c5xBc6
-k7/N7/2n5/2K5/8/8/8/8 w - - ? 1 c5xNc6
-k7/N7/2pK4/8/8/8/8/8 w - - ? 1 d6xPc6
-k7/N7/2qK4/8/8/8/8/8 w - - ? 1 d6xQc6
-k7/N7/2rK4/8/8/8/8/8 w - - ? 1 d6xRc6
-k7/N7/2bK4/8/8/8/8/8 w - - ? 1 d6xBc6
-k7/N7/2nK4/8/8/8/8/8 w - - ? 1 d6xNc6
-k7/N7/1Kp5/8/8/8/8/8 w - - ? 1 b6xPc6
-k7/N7/1Kq5/8/8/8/8/8 w - - ? 1 b6xQc6
-k7/N7/1Kr5/8/8/8/8/8 w - - ? 1 b6xRc6
-k7/N7/1Kb5/8/8/8/8/8 w - - ? 1 b6xBc6
-k7/N7/1Kn5/8/8/8/8/8 w - - ? 1 b6xNc6
-k1N5/8/2K5/8/8/8/8/8 w - - ? 1 (dead) c8a7
-k7/8/2K5/1N6/8/8/8/8 w - - ? 1 (dead) b5a7
-k1N5/p7/2K5/8/8/8/8/8 w - - ? 1 c8xPa7
-k1N5/q7/2K5/8/8/8/8/8 w - - ? 1 c8xQa7
-k1N5/r7/2K5/8/8/8/8/8 w - - ? 1 c8xRa7
-k1N5/b7/2K5/8/8/8/8/8 w - - ? 1 c8xBa7
-k1N5/n7/2K5/8/8/8/8/8 w - - ? 1 c8xNa7
-k7/p7/2K5/1N6/8/8/8/8 w - - ? 1 b5xPa7
-k7/q7/2K5/1N6/8/8/8/8 w - - ? 1 b5xQa7
-k7/r7/2K5/1N6/8/8/8/8 w - - ? 1 b5xRa7
-k7/b7/2K5/1N6/8/8/8/8 w - - ? 1 b5xBa7
-k7/n7/2K5/1N6/8/8/8/8 w - - ? 1 b5xNa7
-nsols 45                                                                        
+nsols 1
+                                                                       
+>>> k7/N7/2K5/8/8/8/8/8 ? >>= r >>= legal
+↶b8a8 dead 1k6/N7/2K5/8/8/8/8/8 b - - ? 0                                       
+↶b8xQa8 dead Qk6/N7/2K5/8/8/8/8/8 b - - ? 0                                     
+↶b8xRa8 dead Rk6/N7/2K5/8/8/8/8/8 b - - ? 0                                     
+↶b8xBa8 dead Bk6/N7/2K5/8/8/8/8/8 b - - ? 0                                     
+↶b8xNa8 dead Nk6/N7/2K5/8/8/8/8/8 b - - ? 0                                     
+↶d7c6 dead k7/N2K4/8/8/8/8/8/8 w - - ? 1                                        
+↶d5c6 dead k7/N7/8/3K4/8/8/8/8 w - - ? 1                                        
+↶b5c6 dead k7/N7/8/1K6/8/8/8/8 w - - ? 1                                        
+↶c7c6 illegal dead k7/N1K5/8/8/8/8/8/8 w - - ? 1                                
+↶c5c6 dead k7/N7/8/2K5/8/8/8/8 w - - ? 1                                        
+↶d6c6 dead k7/N7/3K4/8/8/8/8/8 w - - ? 1                                        
+↶b6c6 zombie k7/N7/1K6/8/8/8/8/8 w - - ? 1                                      
+↶d7xPc6 k7/N2K4/2p5/8/8/8/8/8 w - - ? 1                                         
+↶d7xQc6 k7/N2K4/2q5/8/8/8/8/8 w - - ? 1                                         
+↶d7xRc6 k7/N2K4/2r5/8/8/8/8/8 w - - ? 1                                         
+↶d7xBc6 k7/N2K4/2b5/8/8/8/8/8 w - - ? 1                                         
+↶d7xNc6 k7/N2K4/2n5/8/8/8/8/8 w - - ? 1                                         
+↶d5xPc6 k7/N7/2p5/3K4/8/8/8/8 w - - ? 1                                         
+↶d5xQc6 k7/N7/2q5/3K4/8/8/8/8 w - - ? 1                                         
+↶d5xRc6 k7/N7/2r5/3K4/8/8/8/8 w - - ? 1                                         
+↶d5xBc6 k7/N7/2b5/3K4/8/8/8/8 w - - ? 1                                         
+↶d5xNc6 k7/N7/2n5/3K4/8/8/8/8 w - - ? 1                                         
+↶b5xPc6 k7/N7/2p5/1K6/8/8/8/8 w - - ? 1                                         
+↶b5xQc6 k7/N7/2q5/1K6/8/8/8/8 w - - ? 1                                         
+↶b5xRc6 k7/N7/2r5/1K6/8/8/8/8 w - - ? 1                                         
+↶b5xBc6 k7/N7/2b5/1K6/8/8/8/8 w - - ? 1                                         
+↶b5xNc6 k7/N7/2n5/1K6/8/8/8/8 w - - ? 1                                         
+↶c7xPc6 k7/N1K5/2p5/8/8/8/8/8 w - - ? 1                                         
+↶c7xQc6 k7/N1K5/2q5/8/8/8/8/8 w - - ? 1                                         
+↶c7xRc6 k7/N1K5/2r5/8/8/8/8/8 w - - ? 1                                         
+↶c7xBc6 k7/N1K5/2b5/8/8/8/8/8 w - - ? 1                                         
+↶c7xNc6 k7/N1K5/2n5/8/8/8/8/8 w - - ? 1                                         
+↶c5xPc6 k7/N7/2p5/2K5/8/8/8/8 w - - ? 1                                         
+↶c5xQc6 k7/N7/2q5/2K5/8/8/8/8 w - - ? 1                                         
+↶c5xRc6 k7/N7/2r5/2K5/8/8/8/8 w - - ? 1                                         
+↶c5xBc6 k7/N7/2b5/2K5/8/8/8/8 w - - ? 1                                         
+↶c5xNc6 k7/N7/2n5/2K5/8/8/8/8 w - - ? 1                                         
+↶d6xPc6 k7/N7/2pK4/8/8/8/8/8 w - - ? 1                                          
+↶d6xQc6 k7/N7/2qK4/8/8/8/8/8 w - - ? 1                                          
+↶d6xRc6 k7/N7/2rK4/8/8/8/8/8 w - - ? 1                                          
+↶d6xBc6 k7/N7/2bK4/8/8/8/8/8 w - - ? 1                                          
+↶d6xNc6 k7/N7/2nK4/8/8/8/8/8 w - - ? 1                                          
+↶b6xPc6 k7/N7/1Kp5/8/8/8/8/8 w - - ? 1                                          
+↶b6xQc6 k7/N7/1Kq5/8/8/8/8/8 w - - ? 1                                          
+↶b6xRc6 k7/N7/1Kr5/8/8/8/8/8 w - - ? 1                                          
+↶b6xBc6 k7/N7/1Kb5/8/8/8/8/8 w - - ? 1                                          
+↶b6xNc6 k7/N7/1Kn5/8/8/8/8/8 w - - ? 1                                          
+↶c8a7 dead k1N5/8/2K5/8/8/8/8/8 w - - ? 1                                       
+↶b5a7 dead k7/8/2K5/1N6/8/8/8/8 w - - ? 1                                       
+↶c8xPa7 k1N5/p7/2K5/8/8/8/8/8 w - - ? 1                                         
+↶c8xQa7 k1N5/q7/2K5/8/8/8/8/8 w - - ? 1                                         
+↶c8xRa7 k1N5/r7/2K5/8/8/8/8/8 w - - ? 1                                         
+↶c8xBa7 k1N5/b7/2K5/8/8/8/8/8 w - - ? 1                                         
+↶c8xNa7 k1N5/n7/2K5/8/8/8/8/8 w - - ? 1                                         
+↶b5xPa7 k7/p7/2K5/1N6/8/8/8/8 w - - ? 1                                         
+↶b5xQa7 k7/q7/2K5/1N6/8/8/8/8 w - - ? 1                                         
+↶b5xRa7 k7/r7/2K5/1N6/8/8/8/8 w - - ? 1                                         
+↶b5xBa7 k7/b7/2K5/1N6/8/8/8/8 w - - ? 1                                         
+↶b5xNa7 k7/n7/2K5/1N6/8/8/8/8 w - - ? 1                                         
+nsols 45
+                                                                       
 // 6 - P1001037 Andrew Buchanan 3 Retros mailing list 24/01/2001
->>> kB6/2K5/8/2N5/8/8/8/8 ? >>= turn
+>>> kB6/2K5/8/2N5/8/8/8/8 ? >>= legal >>= turn
 b
-nsols 1                                                                        
->>> kB6/2K5/8/2N5/8/8/8/8 ? >>= r
-1B6/k1K5/8/2N5/8/8/8/8 b - - ? 0 (dead) a7a8
-QB6/k1K5/8/2N5/8/8/8/8 b - - ? 0 (illegal) a7xQa8
-RB6/k1K5/8/2N5/8/8/8/8 b - - ? 0 (illegal) a7xRa8
-BB6/k1K5/8/2N5/8/8/8/8 b - - ? 0 (dead) a7xBa8
-NB6/k1K5/8/2N5/8/8/8/8 b - - ? 0 (dead) a7xNa8
-kB6/2KN4/8/8/8/8/8/8 w - - ? 1 d7c5
-kB6/2K5/4N3/8/8/8/8/8 w - - ? 1 e6c5
-kB6/1NK5/8/8/8/8/8/8 w - - ? 1 (dead) b7c5
-kB6/2K5/N7/8/8/8/8/8 w - - ? 1 a6c5
-kB6/2K5/8/8/8/3N4/8/8 w - - ? 1 d3c5
-kB6/2K5/8/8/4N3/8/8/8 w - - ? 1 e4c5
-kB6/2K5/8/8/8/1N6/8/8 w - - ? 1 b3c5
-kB6/2K5/8/8/N7/8/8/8 w - - ? 1 a4c5
-kB6/2KN4/8/2p5/8/8/8/8 w - - ? 1 d7xPc5
-kB6/2KN4/8/2q5/8/8/8/8 w - - ? 1 d7xQc5
-kB6/2KN4/8/2r5/8/8/8/8 w - - ? 1 d7xRc5
-kB6/2KN4/8/2b5/8/8/8/8 w - - ? 1 d7xBc5
-kB6/2KN4/8/2n5/8/8/8/8 w - - ? 1 d7xNc5
-kB6/2K5/4N3/2p5/8/8/8/8 w - - ? 1 e6xPc5
-kB6/2K5/4N3/2q5/8/8/8/8 w - - ? 1 e6xQc5
-kB6/2K5/4N3/2r5/8/8/8/8 w - - ? 1 e6xRc5
-kB6/2K5/4N3/2b5/8/8/8/8 w - - ? 1 e6xBc5
-kB6/2K5/4N3/2n5/8/8/8/8 w - - ? 1 e6xNc5
-kB6/1NK5/8/2p5/8/8/8/8 w - - ? 1 b7xPc5
-kB6/1NK5/8/2q5/8/8/8/8 w - - ? 1 b7xQc5
-kB6/1NK5/8/2r5/8/8/8/8 w - - ? 1 b7xRc5
-kB6/1NK5/8/2b5/8/8/8/8 w - - ? 1 b7xBc5
-kB6/1NK5/8/2n5/8/8/8/8 w - - ? 1 b7xNc5
-kB6/2K5/N7/2p5/8/8/8/8 w - - ? 1 a6xPc5
-kB6/2K5/N7/2q5/8/8/8/8 w - - ? 1 a6xQc5
-kB6/2K5/N7/2r5/8/8/8/8 w - - ? 1 a6xRc5
-kB6/2K5/N7/2b5/8/8/8/8 w - - ? 1 a6xBc5
-kB6/2K5/N7/2n5/8/8/8/8 w - - ? 1 a6xNc5
-kB6/2K5/8/2p5/8/3N4/8/8 w - - ? 1 d3xPc5
-kB6/2K5/8/2q5/8/3N4/8/8 w - - ? 1 d3xQc5
-kB6/2K5/8/2r5/8/3N4/8/8 w - - ? 1 d3xRc5
-kB6/2K5/8/2b5/8/3N4/8/8 w - - ? 1 d3xBc5
-kB6/2K5/8/2n5/8/3N4/8/8 w - - ? 1 d3xNc5
-kB6/2K5/8/2p5/4N3/8/8/8 w - - ? 1 e4xPc5
-kB6/2K5/8/2q5/4N3/8/8/8 w - - ? 1 e4xQc5
-kB6/2K5/8/2r5/4N3/8/8/8 w - - ? 1 e4xRc5
-kB6/2K5/8/2b5/4N3/8/8/8 w - - ? 1 e4xBc5
-kB6/2K5/8/2n5/4N3/8/8/8 w - - ? 1 e4xNc5
-kB6/2K5/8/2p5/8/1N6/8/8 w - - ? 1 b3xPc5
-kB6/2K5/8/2q5/8/1N6/8/8 w - - ? 1 b3xQc5
-kB6/2K5/8/2r5/8/1N6/8/8 w - - ? 1 b3xRc5
-kB6/2K5/8/2b5/8/1N6/8/8 w - - ? 1 b3xBc5
-kB6/2K5/8/2n5/8/1N6/8/8 w - - ? 1 b3xNc5
-kB6/2K5/8/2p5/N7/8/8/8 w - - ? 1 a4xPc5
-kB6/2K5/8/2q5/N7/8/8/8 w - - ? 1 a4xQc5
-kB6/2K5/8/2r5/N7/8/8/8 w - - ? 1 a4xRc5
-kB6/2K5/8/2b5/N7/8/8/8 w - - ? 1 a4xBc5
-kB6/2K5/8/2n5/N7/8/8/8 w - - ? 1 a4xNc5
-kB1K4/8/8/2N5/8/8/8/8 w - - ? 1 d8c7
-kB6/8/3K4/2N5/8/8/8/8 w - - ? 1 d6c7
-kB6/8/1K6/2N5/8/8/8/8 w - - ? 1 (illegal) b6c7
-kBK5/8/8/2N5/8/8/8/8 w - - ? 1 c8c7
-kB6/8/2K5/2N5/8/8/8/8 w - - ? 1 c6c7
-kB6/3K4/8/2N5/8/8/8/8 w - - ? 1 d7c7
-kB1K4/2p5/8/2N5/8/8/8/8 w - - ? 1 d8xPc7
-kB1K4/2q5/8/2N5/8/8/8/8 w - - ? 1 d8xQc7
-kB1K4/2r5/8/2N5/8/8/8/8 w - - ? 1 d8xRc7
-kB1K4/2b5/8/2N5/8/8/8/8 w - - ? 1 d8xBc7
-kB1K4/2n5/8/2N5/8/8/8/8 w - - ? 1 d8xNc7
-kB6/2p5/3K4/2N5/8/8/8/8 w - - ? 1 (illegal) d6xPc7
-kB6/2q5/3K4/2N5/8/8/8/8 w - - ? 1 d6xQc7
-kB6/2r5/3K4/2N5/8/8/8/8 w - - ? 1 d6xRc7
-kB6/2b5/3K4/2N5/8/8/8/8 w - - ? 1 d6xBc7
-kB6/2n5/3K4/2N5/8/8/8/8 w - - ? 1 d6xNc7
-kB6/2p5/1K6/2N5/8/8/8/8 w - - ? 1 (illegal) b6xPc7
-kB6/2q5/1K6/2N5/8/8/8/8 w - - ? 1 b6xQc7
-kB6/2r5/1K6/2N5/8/8/8/8 w - - ? 1 b6xRc7
-kB6/2b5/1K6/2N5/8/8/8/8 w - - ? 1 b6xBc7
-kB6/2n5/1K6/2N5/8/8/8/8 w - - ? 1 b6xNc7
-kBK5/2p5/8/2N5/8/8/8/8 w - - ? 1 c8xPc7
-kBK5/2q5/8/2N5/8/8/8/8 w - - ? 1 c8xQc7
-kBK5/2r5/8/2N5/8/8/8/8 w - - ? 1 c8xRc7
-kBK5/2b5/8/2N5/8/8/8/8 w - - ? 1 c8xBc7
-kBK5/2n5/8/2N5/8/8/8/8 w - - ? 1 c8xNc7
-kB6/2p5/2K5/2N5/8/8/8/8 w - - ? 1 c6xPc7
-kB6/2q5/2K5/2N5/8/8/8/8 w - - ? 1 c6xQc7
-kB6/2r5/2K5/2N5/8/8/8/8 w - - ? 1 c6xRc7
-kB6/2b5/2K5/2N5/8/8/8/8 w - - ? 1 c6xBc7
-kB6/2n5/2K5/2N5/8/8/8/8 w - - ? 1 c6xNc7
-kB6/2pK4/8/2N5/8/8/8/8 w - - ? 1 d7xPc7
-kB6/2qK4/8/2N5/8/8/8/8 w - - ? 1 d7xQc7
-kB6/2rK4/8/2N5/8/8/8/8 w - - ? 1 d7xRc7
-kB6/2bK4/8/2N5/8/8/8/8 w - - ? 1 d7xBc7
-kB6/2nK4/8/2N5/8/8/8/8 w - - ? 1 d7xNc7
-k7/B1K5/8/2N5/8/8/8/8 w - - ? 1 (illegal) a7b8
-kq6/B1K5/8/2N5/8/8/8/8 w - - ? 1 a7xQb8
-kr6/B1K5/8/2N5/8/8/8/8 w - - ? 1 a7xRb8
-kb6/B1K5/8/2N5/8/8/8/8 w - - ? 1 (illegal) a7xBb8
-kn6/B1K5/8/2N5/8/8/8/8 w - - ? 1 a7xNb8
-kq6/P1K5/8/2N5/8/8/8/8 w - - ? 1 a7xQb8prom
-kr6/P1K5/8/2N5/8/8/8/8 w - - ? 1 a7xRb8prom
-kb6/P1K5/8/2N5/8/8/8/8 w - - ? 1 (illegal) a7xBb8prom
-kn6/P1K5/8/2N5/8/8/8/8 w - - ? 1 a7xNb8prom
-nsols 86                                                                        
+nsols 1
+                                                                       
+>>> kB6/2K5/8/2N5/8/8/8/8 ? >>= r >>= legal
+↶a7a8 dead 1B6/k1K5/8/2N5/8/8/8/8 b - - ? 0                                     
+↶a7xQa8 illegal dead QB6/k1K5/8/2N5/8/8/8/8 b - - ? 0                           
+↶a7xRa8 illegal dead RB6/k1K5/8/2N5/8/8/8/8 b - - ? 0                           
+↶a7xBa8 dead BB6/k1K5/8/2N5/8/8/8/8 b - - ? 0                                   
+↶a7xNa8 dead NB6/k1K5/8/2N5/8/8/8/8 b - - ? 0                                   
+↶d7c5 kB6/2KN4/8/8/8/8/8/8 w - - ? 1                                            
+↶e6c5 kB6/2K5/4N3/8/8/8/8/8 w - - ? 1                                           
+↶b7c5 illegal dead kB6/1NK5/8/8/8/8/8/8 w - - ? 1                               
+↶a6c5 kB6/2K5/N7/8/8/8/8/8 w - - ? 1                                            
+↶d3c5 kB6/2K5/8/8/8/3N4/8/8 w - - ? 1                                           
+↶e4c5 kB6/2K5/8/8/4N3/8/8/8 w - - ? 1                                           
+↶b3c5 kB6/2K5/8/8/8/1N6/8/8 w - - ? 1                                           
+↶a4c5 kB6/2K5/8/8/N7/8/8/8 w - - ? 1                                            
+↶d7xPc5 kB6/2KN4/8/2p5/8/8/8/8 w - - ? 1                                        
+↶d7xQc5 kB6/2KN4/8/2q5/8/8/8/8 w - - ? 1                                        
+↶d7xRc5 kB6/2KN4/8/2r5/8/8/8/8 w - - ? 1                                        
+↶d7xBc5 kB6/2KN4/8/2b5/8/8/8/8 w - - ? 1                                        
+↶d7xNc5 kB6/2KN4/8/2n5/8/8/8/8 w - - ? 1                                        
+↶e6xPc5 kB6/2K5/4N3/2p5/8/8/8/8 w - - ? 1                                       
+↶e6xQc5 kB6/2K5/4N3/2q5/8/8/8/8 w - - ? 1                                       
+↶e6xRc5 kB6/2K5/4N3/2r5/8/8/8/8 w - - ? 1                                       
+↶e6xBc5 kB6/2K5/4N3/2b5/8/8/8/8 w - - ? 1                                       
+↶e6xNc5 kB6/2K5/4N3/2n5/8/8/8/8 w - - ? 1                                       
+↶b7xPc5 kB6/1NK5/8/2p5/8/8/8/8 w - - ? 1                                        
+↶b7xQc5 kB6/1NK5/8/2q5/8/8/8/8 w - - ? 1                                        
+↶b7xRc5 kB6/1NK5/8/2r5/8/8/8/8 w - - ? 1                                        
+↶b7xBc5 kB6/1NK5/8/2b5/8/8/8/8 w - - ? 1                                        
+↶b7xNc5 kB6/1NK5/8/2n5/8/8/8/8 w - - ? 1                                        
+↶a6xPc5 kB6/2K5/N7/2p5/8/8/8/8 w - - ? 1                                        
+↶a6xQc5 kB6/2K5/N7/2q5/8/8/8/8 w - - ? 1                                        
+↶a6xRc5 kB6/2K5/N7/2r5/8/8/8/8 w - - ? 1                                        
+↶a6xBc5 kB6/2K5/N7/2b5/8/8/8/8 w - - ? 1                                        
+↶a6xNc5 kB6/2K5/N7/2n5/8/8/8/8 w - - ? 1                                        
+↶d3xPc5 kB6/2K5/8/2p5/8/3N4/8/8 w - - ? 1                                       
+↶d3xQc5 kB6/2K5/8/2q5/8/3N4/8/8 w - - ? 1                                       
+↶d3xRc5 kB6/2K5/8/2r5/8/3N4/8/8 w - - ? 1                                       
+↶d3xBc5 kB6/2K5/8/2b5/8/3N4/8/8 w - - ? 1                                       
+↶d3xNc5 kB6/2K5/8/2n5/8/3N4/8/8 w - - ? 1                                       
+↶e4xPc5 kB6/2K5/8/2p5/4N3/8/8/8 w - - ? 1                                       
+↶e4xQc5 kB6/2K5/8/2q5/4N3/8/8/8 w - - ? 1                                       
+↶e4xRc5 kB6/2K5/8/2r5/4N3/8/8/8 w - - ? 1                                       
+↶e4xBc5 kB6/2K5/8/2b5/4N3/8/8/8 w - - ? 1                                       
+↶e4xNc5 kB6/2K5/8/2n5/4N3/8/8/8 w - - ? 1                                       
+↶b3xPc5 kB6/2K5/8/2p5/8/1N6/8/8 w - - ? 1                                       
+↶b3xQc5 kB6/2K5/8/2q5/8/1N6/8/8 w - - ? 1                                       
+↶b3xRc5 kB6/2K5/8/2r5/8/1N6/8/8 w - - ? 1                                       
+↶b3xBc5 kB6/2K5/8/2b5/8/1N6/8/8 w - - ? 1                                       
+↶b3xNc5 kB6/2K5/8/2n5/8/1N6/8/8 w - - ? 1                                       
+↶a4xPc5 kB6/2K5/8/2p5/N7/8/8/8 w - - ? 1                                        
+↶a4xQc5 kB6/2K5/8/2q5/N7/8/8/8 w - - ? 1                                        
+↶a4xRc5 kB6/2K5/8/2r5/N7/8/8/8 w - - ? 1                                        
+↶a4xBc5 kB6/2K5/8/2b5/N7/8/8/8 w - - ? 1                                        
+↶a4xNc5 kB6/2K5/8/2n5/N7/8/8/8 w - - ? 1                                        
+↶d8c7 kB1K4/8/8/2N5/8/8/8/8 w - - ? 1                                           
+↶d6c7 kB6/8/3K4/2N5/8/8/8/8 w - - ? 1                                           
+↶b6c7 illegal dead kB6/8/1K6/2N5/8/8/8/8 w - - ? 1                              
+↶c8c7 kBK5/8/8/2N5/8/8/8/8 w - - ? 1                                            
+↶c6c7 kB6/8/2K5/2N5/8/8/8/8 w - - ? 1                                           
+↶d7c7 kB6/3K4/8/2N5/8/8/8/8 w - - ? 1                                           
+↶d8xPc7 kB1K4/2p5/8/2N5/8/8/8/8 w - - ? 1                                       
+↶d8xQc7 kB1K4/2q5/8/2N5/8/8/8/8 w - - ? 1                                       
+↶d8xRc7 kB1K4/2r5/8/2N5/8/8/8/8 w - - ? 1                                       
+↶d8xBc7 kB1K4/2b5/8/2N5/8/8/8/8 w - - ? 1                                       
+↶d8xNc7 kB1K4/2n5/8/2N5/8/8/8/8 w - - ? 1                                       
+↶d6xPc7 illegal kB6/2p5/3K4/2N5/8/8/8/8 w - - ? 1                               
+↶d6xQc7 kB6/2q5/3K4/2N5/8/8/8/8 w - - ? 1                                       
+↶d6xRc7 kB6/2r5/3K4/2N5/8/8/8/8 w - - ? 1                                       
+↶d6xBc7 kB6/2b5/3K4/2N5/8/8/8/8 w - - ? 1                                       
+↶d6xNc7 kB6/2n5/3K4/2N5/8/8/8/8 w - - ? 1                                       
+↶b6xPc7 illegal kB6/2p5/1K6/2N5/8/8/8/8 w - - ? 1                               
+↶b6xQc7 kB6/2q5/1K6/2N5/8/8/8/8 w - - ? 1                                       
+↶b6xRc7 kB6/2r5/1K6/2N5/8/8/8/8 w - - ? 1                                       
+↶b6xBc7 kB6/2b5/1K6/2N5/8/8/8/8 w - - ? 1                                       
+↶b6xNc7 kB6/2n5/1K6/2N5/8/8/8/8 w - - ? 1                                       
+↶c8xPc7 kBK5/2p5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶c8xQc7 kBK5/2q5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶c8xRc7 kBK5/2r5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶c8xBc7 kBK5/2b5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶c8xNc7 kBK5/2n5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶c6xPc7 kB6/2p5/2K5/2N5/8/8/8/8 w - - ? 1                                       
+↶c6xQc7 kB6/2q5/2K5/2N5/8/8/8/8 w - - ? 1                                       
+↶c6xRc7 kB6/2r5/2K5/2N5/8/8/8/8 w - - ? 1                                       
+↶c6xBc7 kB6/2b5/2K5/2N5/8/8/8/8 w - - ? 1                                       
+↶c6xNc7 kB6/2n5/2K5/2N5/8/8/8/8 w - - ? 1                                       
+↶d7xPc7 kB6/2pK4/8/2N5/8/8/8/8 w - - ? 1                                        
+↶d7xQc7 kB6/2qK4/8/2N5/8/8/8/8 w - - ? 1                                        
+↶d7xRc7 kB6/2rK4/8/2N5/8/8/8/8 w - - ? 1                                        
+↶d7xBc7 kB6/2bK4/8/2N5/8/8/8/8 w - - ? 1                                        
+↶d7xNc7 kB6/2nK4/8/2N5/8/8/8/8 w - - ? 1                                        
+↶a7b8 illegal dead k7/B1K5/8/2N5/8/8/8/8 w - - ? 1                              
+↶a7xQb8 kq6/B1K5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶a7xRb8 kr6/B1K5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶a7xBb8 illegal kb6/B1K5/8/2N5/8/8/8/8 w - - ? 1                                
+↶a7xNb8 kn6/B1K5/8/2N5/8/8/8/8 w - - ? 1                                        
+↶a7xQb8prom kq6/P1K5/8/2N5/8/8/8/8 w - - ? 1                                    
+↶a7xRb8prom kr6/P1K5/8/2N5/8/8/8/8 w - - ? 1                                    
+↶a7xBb8prom illegal kb6/P1K5/8/2N5/8/8/8/8 w - - ? 1                            
+↶a7xNb8prom kn6/P1K5/8/2N5/8/8/8/8 w - - ? 1                                    
+nsols 86
+                                                                       
 // 7 - P1001038 Andrew Buchanan 4v Retros mailing list 21/01/2001
->>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= castling
+>>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= r >>= legal
+↶e4e3 8/7Q/8/4BB2/2PPkP2/3N1N2/PP2P1P1/4K2R b K - ? 0                           
+↶e4xPe3 8/7Q/8/4BB2/2PPkP2/3NPN2/PP2P1P1/4K2R b K - ? 0                         
+↶e4xQe3 illegal 8/7Q/8/4BB2/2PPkP2/3NQN2/PP2P1P1/4K2R b K - ? 0                 
+↶e4xRe3 illegal 8/7Q/8/4BB2/2PPkP2/3NRN2/PP2P1P1/4K2R b K - ? 0                 
+↶e4xBe3 8/7Q/8/4BB2/2PPkP2/3NBN2/PP2P1P1/4K2R b K - ? 0                         
+↶e4xNe3 8/7Q/8/4BB2/2PPkP2/3NNN2/PP2P1P1/4K2R b K - ? 0                         
+↶e4e3 dead 8/7Q/8/4BB2/2PPkP2/3N1N2/PP2P1P1/4K2R b - - ? 0                      
+↶e4xPe3 dead 8/7Q/8/4BB2/2PPkP2/3NPN2/PP2P1P1/4K2R b - - ? 0                    
+↶e4xQe3 illegal dead 8/7Q/8/4BB2/2PPkP2/3NQN2/PP2P1P1/4K2R b - - ? 0            
+↶e4xRe3 illegal dead 8/7Q/8/4BB2/2PPkP2/3NRN2/PP2P1P1/4K2R b - - ? 0            
+↶e4xBe3 dead 8/7Q/8/4BB2/2PPkP2/3NBN2/PP2P1P1/4K2R b - - ? 0                    
+↶e4xNe3 dead 8/7Q/8/4BB2/2PPkP2/3NNN2/PP2P1P1/4K2R b - - ? 0                    
+nsols 4
+                                                                       
+>>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= legal >>= castling
 K
-nsols 1                                                                        
->>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= r
-8/7Q/8/4BB2/2PPkP2/3N1N2/PP2P1P1/4K2R b K - ? 0 e4e3
-8/7Q/8/4BB2/2PPkP2/3NPN2/PP2P1P1/4K2R b K - ? 0 e4xPe3
-8/7Q/8/4BB2/2PPkP2/3NQN2/PP2P1P1/4K2R b K - ? 0 (illegal) e4xQe3
-8/7Q/8/4BB2/2PPkP2/3NRN2/PP2P1P1/4K2R b K - ? 0 (illegal) e4xRe3
-8/7Q/8/4BB2/2PPkP2/3NBN2/PP2P1P1/4K2R b K - ? 0 e4xBe3
-8/7Q/8/4BB2/2PPkP2/3NNN2/PP2P1P1/4K2R b K - ? 0 e4xNe3
-8/7Q/8/4BB2/2PPkP2/3N1N2/PP2P1P1/4K2R b - - ? 0 (dead) e4e3
-8/7Q/8/4BB2/2PPkP2/3NPN2/PP2P1P1/4K2R b - - ? 0 (dead) e4xPe3
-8/7Q/8/4BB2/2PPkP2/3NQN2/PP2P1P1/4K2R b - - ? 0 (illegal) e4xQe3
-8/7Q/8/4BB2/2PPkP2/3NRN2/PP2P1P1/4K2R b - - ? 0 (illegal) e4xRe3
-8/7Q/8/4BB2/2PPkP2/3NBN2/PP2P1P1/4K2R b - - ? 0 (dead) e4xBe3
-8/7Q/8/4BB2/2PPkP2/3NNN2/PP2P1P1/4K2R b - - ? 0 (dead) e4xNe3
-nsols 4                                                                        
->>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= #2
-e1g1 ... #                                                                      
-nsols 1                                                                        
+nsols 1
+                                                                       
+>>> 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w K >>= #2 >>= legal
+e1g1 ... # 8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/5RK1 b - - 1 1                      
+nsols 1
+                                                                       
 // 8 - P1001041 Andrew Buchanan 7 Retros mailing list 24/01/2001
->>> k7/P7/B1K5/8/8/8/8/8 w >>= r
-1k6/P7/B1K5/8/8/8/8/8 b - - ? 0 (dead) b8a8
-Qk6/P7/B1K5/8/8/8/8/8 b - - ? 0 (illegal) b8xQa8
-Rk6/P7/B1K5/8/8/8/8/8 b - - ? 0 (illegal) b8xRa8
-Bk6/P7/B1K5/8/8/8/8/8 b - - ? 0 (dead) b8xBa8
-Nk6/P7/B1K5/8/8/8/8/8 b - - ? 0 b8xNa8
-nsols 1                                                                        
+>>> k7/P7/B1K5/8/8/8/8/8 w >>= r >>= legal
+↶b8a8 dead 1k6/P7/B1K5/8/8/8/8/8 b - - ? 0                                      
+↶b8xQa8 illegal dead Qk6/P7/B1K5/8/8/8/8/8 b - - ? 0                            
+↶b8xRa8 illegal dead Rk6/P7/B1K5/8/8/8/8/8 b - - ? 0                            
+↶b8xBa8 dead Bk6/P7/B1K5/8/8/8/8/8 b - - ? 0                                    
+↶b8xNa8 Nk6/P7/B1K5/8/8/8/8/8 b - - ? 0                                         
+nsols 1
+                                                                       
 // 9 - P1003981 Andrew Buchanan R0093 StrateGems 18 04-06/2002
->>> Bb1k1b2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 w >>= r
-Bb1k1b2/bKp1p1p1/1pP1P1P1/pP6/6P1/P7/8/8 b - - ? 0 a5a4
-Bb3b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (illegal) d7d8
-Bb2kb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (dead) e8d8
-Bb1Q1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (illegal) d7xQd8
-Bb1R1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (illegal) d7xRd8
-Bb1B1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (illegal) d7xBd8
-Bb1N1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (illegal) d7xNd8
-Bb1Qkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (dead) e8xQd8
-Bb1Rkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (dead) e8xRd8
-Bb1Bkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (dead) e8xBd8
-Bb1Nkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0 (dead) e8xNd8
-nsols 1                                                                        
+>>> Bb1k1b2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 w >>= r >>= legal
+↶a5a4 Bb1k1b2/bKp1p1p1/1pP1P1P1/pP6/6P1/P7/8/8 b - - ? 0                        
+↶d7d8 illegal Bb3b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0                 
+↶e8d8 dead Bb2kb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0                   
+↶d7xQd8 illegal Bb1Q1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0             
+↶d7xRd8 illegal Bb1R1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0             
+↶d7xBd8 illegal Bb1B1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0             
+↶d7xNd8 illegal Bb1N1b2/bKpkp1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0             
+↶e8xQd8 dead Bb1Qkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0                
+↶e8xRd8 dead Bb1Rkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0                
+↶e8xBd8 dead Bb1Bkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0                
+↶e8xNd8 dead Bb1Nkb2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 b - - ? 0                
+nsols 1
+                                                                       
 // 10 - P1004031 Andrew Buchanan R0089 StrateGems 16 10-12/2001
->>> 1Nk3K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 w >>= r
-1N4K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (dead) b7c8
-1N1k2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 d8c8
-1NQ3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (illegal) b7xQc8
-1NR3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (dead) b7xRc8
-1NB3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (illegal) b7xBc8
-1NN3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (dead) b7xNc8
-1NQk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (illegal) d8xQc8
-1NRk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (illegal) d8xRc8
-1NBk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (dead) d8xBc8
-1NNk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0 (dead) d8xNc8
-nsols 1                                                                        
+>>> 1Nk3K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 w >>= r >>= legal
+↶b7c8 dead 1N4K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                       
+↶d8c8 1N1k2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                          
+↶b7xQc8 illegal 1NQ3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                 
+↶b7xRc8 dead 1NR3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                    
+↶b7xBc8 illegal 1NB3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                 
+↶b7xNc8 dead 1NN3K1/PkPN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                    
+↶d8xQc8 illegal 1NQk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                
+↶d8xRc8 illegal 1NRk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                
+↶d8xBc8 dead 1NBk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                   
+↶d8xNc8 dead 1NNk2K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 b - - ? 0                   
+nsols 1
+                                                                       
 // 11 - P1112386 Mrs. W. J. Baird (2) British Chess Magazine, p. 136, 03/1903
 // 12 - P1123642 Mrs. W. J. Baird Revue d'Echecs 1903?
->>> 8/8/8/pN1k4/3p1PB1/1K6/8/8 b >>= r >>= h#1.5
-e3xNf4 then e3d4 f4e6 g4f3#                                                     
-nsols 1                                                                        
+>>> 8/8/8/pN1k4/3p1PB1/1K6/8/8 b >>= r >>= h#1.5 >>= legal
+↶e3xNf4 e3d4 f4e6 g4f3# 8/8/4n3/pN1k4/3P2B1/1K6/8/8 w - - 1 2                   
+nsols 1
+                                                                       
 // 13 - P1183694 Mrs. W. J. Baird 2 British Chess Magazine, p. 491, 12/1903 (2 solutions)
 // 14 - P1183695 Mrs. W. J. Baird 3 British Chess Magazine, p. 492, 12/1903 (3 solutions)
 // 15 - P1183698 Mrs. W. J. Baird London Field
->>> 1K6/2R1p3/r1P5/1N6/1Nk5/P1nnP3/3P4/2b5 b >>= r >>= h#1.5
-c5c6 then b5d4 d3c5 d2d3#                                                       
-nsols 1                                                                        
+>>> 1K6/2R1p3/r1P5/1N6/1Nk5/P1nnP3/3P4/2b5 b >>= r >>= h#1.5 >>= legal
+↶c5c6 b5d4 d3c5 d2d3# 1K6/2R1p3/r7/2n5/1NkN4/P1n1P3/3P4/2b5 w - - 0 2           
+nsols 1
+                                                                       
 // 16 - P1183934 Mrs. W. J. Baird Cheltenham Examiner
 // 17 - P1183936 Mrs. W. J. Baird Leader (Jamaika)
->>> 3k4/8/8/1N3P2/3B4/8/3K4/8 b >>= r >>= h#1.5
-d6xBb5 then f5f6 b5d7 d4b6#                                                     
-nsols 1                                                                        
+>>> 3k4/8/8/1N3P2/3B4/8/3K4/8 b >>= r >>= h#1.5 >>= legal
+↶d6xBb5 f5f6 b5d7 d4b6# 3k4/3b4/3N1P2/8/3B4/8/3K4/8 w - - 1 2                   
+nsols 1
+                                                                       
 // 18 - P1183995 Mrs. W. J. Baird 3 Leisure Hour, p. 527, 1904
->>> 8/2K1p3/1n2N3/3kN3/1P3P2/8/8/8 b >>= r >>= h#1.5
-f3f4 then e5c6 b6c4 e6f4#                                                       
-nsols 1                                                                        
+>>> 8/2K1p3/1n2N3/3kN3/1P3P2/8/8/8 b >>= r >>= h#1.5 >>= legal
+↶f3f4 e5c6 b6c4 e6f4# 8/2K1p3/2N1N3/3k4/1Pn5/5P2/8/8 w - - 2 2                  
+nsols 1
+                                                                       
 // 19 - P1184001 Mrs. W. J. Baird 144 The Times 17/06/1904
 // 20 - P1184464 Mrs. W. J. Baird Leisure Hour 1906
 // 21 - P1185570 Mrs. W. J. Baird Reading Observer
 // 22 - P1414378 Mrs. W. J. Baird & Miguel Ambrona & Andrew Buchanan (Correction of P1185584)
 // 23 - P1185751 Mrs. W. J. Baird Bolton Cricket and Football Field
->>> 3K4/4pN2/8/2p5/3k4/2p1R3/8/8 b >>= r >>= h#1.5
-e1xPe3 then f7d6 e7e5 e1d1#                                                     
-nsols 1                                                                        
+>>> 3K4/4pN2/8/2p5/3k4/2p1R3/8/8 b >>= r >>= h#1.5 >>= legal
+↶e1xPe3 f7d6 e7e5 e1d1# 3K4/8/3N4/2p1p3/3k4/2p1p3/8/4R3 w - - 0 2               
+nsols 1
+                                                                       
 // 24 - P1187856 Mrs. W. J. Baird Morning Post
->>> 1R6/1bNB2n1/pk2P3/pN2p2p/3pP2K/3P3p/5B1P/6n1 b >>= r >>= #2
-e8c7 then b5d4 ... #                                                            
-nsols 1                                                                        
+>>> 1R6/1bNB2n1/pk2P3/pN2p2p/3pP2K/3P3p/5B1P/6n1 b >>= r >>= #2 >>= legal
+↶e8c7 b5d4 ... # 1R2N3/1b1B2n1/pk2P3/p3p2p/3NP2K/3P3p/5B1P/6n1 b - - 0 1        
+nsols 1
+                                                                       
 // 25 - P1244258 Andrew Buchanan Retros mailing list 01/2001
->>> 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= castling
+>>> 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= r >>= legal
+↶f4e3 illegal 8/8/2Q1N3/3B4/2PP1k2/3N3P/2P5/B2RK2R b K - ? 0                    
+↶e4e3 illegal 8/8/2Q1N3/3B4/2PPk3/3N3P/2P5/B2RK2R b K - ? 0                     
+↶f3e3 illegal 8/8/2Q1N3/3B4/2PP4/3N1k1P/2P5/B2RK2R b K - ? 0                    
+↶f4xPe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NP2P/2P5/B2RK2R b K - ? 0                 
+↶f4xQe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NQ2P/2P5/B2RK2R b K - ? 0                 
+↶f4xRe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NR2P/2P5/B2RK2R b K - ? 0                 
+↶f4xBe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NB2P/2P5/B2RK2R b K - ? 0                 
+↶f4xNe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NN2P/2P5/B2RK2R b K - ? 0                 
+↶e4xPe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NP2P/2P5/B2RK2R b K - ? 0                  
+↶e4xQe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NQ2P/2P5/B2RK2R b K - ? 0                  
+↶e4xRe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NR2P/2P5/B2RK2R b K - ? 0                  
+↶e4xBe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NB2P/2P5/B2RK2R b K - ? 0                  
+↶e4xNe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NN2P/2P5/B2RK2R b K - ? 0                  
+↶f3xPe3 illegal 8/8/2Q1N3/3B4/2PP4/3NPk1P/2P5/B2RK2R b K - ? 0                  
+↶f3xQe3 illegal 8/8/2Q1N3/3B4/2PP4/3NQk1P/2P5/B2RK2R b K - ? 0                  
+↶f3xRe3 8/8/2Q1N3/3B4/2PP4/3NRk1P/2P5/B2RK2R b K - ? 0                          
+↶f3xBe3 illegal 8/8/2Q1N3/3B4/2PP4/3NBk1P/2P5/B2RK2R b K - ? 0                  
+↶f3xNe3 illegal 8/8/2Q1N3/3B4/2PP4/3NNk1P/2P5/B2RK2R b K - ? 0                  
+↶f4e3 illegal 8/8/2Q1N3/3B4/2PP1k2/3N3P/2P5/B2RK2R b - - ? 0                    
+↶e4e3 illegal 8/8/2Q1N3/3B4/2PPk3/3N3P/2P5/B2RK2R b - - ? 0                     
+↶f3e3 illegal 8/8/2Q1N3/3B4/2PP4/3N1k1P/2P5/B2RK2R b - - ? 0                    
+↶f4xPe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NP2P/2P5/B2RK2R b - - ? 0                 
+↶f4xQe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NQ2P/2P5/B2RK2R b - - ? 0                 
+↶f4xRe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NR2P/2P5/B2RK2R b - - ? 0                 
+↶f4xBe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NB2P/2P5/B2RK2R b - - ? 0                 
+↶f4xNe3 illegal 8/8/2Q1N3/3B4/2PP1k2/3NN2P/2P5/B2RK2R b - - ? 0                 
+↶e4xPe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NP2P/2P5/B2RK2R b - - ? 0                  
+↶e4xQe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NQ2P/2P5/B2RK2R b - - ? 0                  
+↶e4xRe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NR2P/2P5/B2RK2R b - - ? 0                  
+↶e4xBe3 illegal 8/8/2Q1N3/3B4/2PPk3/3NB2P/2P5/B2RK2R b - - ? 0                  
+↶e4xNe3 illegal dead 8/8/2Q1N3/3B4/2PPk3/3NN2P/2P5/B2RK2R b - - ? 0             
+↶f3xPe3 illegal 8/8/2Q1N3/3B4/2PP4/3NPk1P/2P5/B2RK2R b - - ? 0                  
+↶f3xQe3 illegal dead 8/8/2Q1N3/3B4/2PP4/3NQk1P/2P5/B2RK2R b - - ? 0             
+↶f3xRe3 dead 8/8/2Q1N3/3B4/2PP4/3NRk1P/2P5/B2RK2R b - - ? 0                     
+↶f3xBe3 illegal 8/8/2Q1N3/3B4/2PP4/3NBk1P/2P5/B2RK2R b - - ? 0                  
+↶f3xNe3 illegal 8/8/2Q1N3/3B4/2PP4/3NNk1P/2P5/B2RK2R b - - ? 0                  
+nsols 1
+                                                                       
+>>> 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= legal >>= castling
 K
--
-nsols 2                                                                        
->>> 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= r
-8/8/2Q1N3/3B4/2PP1k2/3N3P/2P5/B2RK2R b K - ? 0 (illegal) f4e3
-8/8/2Q1N3/3B4/2PPk3/3N3P/2P5/B2RK2R b K - ? 0 (illegal) e4e3
-8/8/2Q1N3/3B4/2PP4/3N1k1P/2P5/B2RK2R b K - ? 0 (illegal) f3e3
-8/8/2Q1N3/3B4/2PP1k2/3NP2P/2P5/B2RK2R b K - ? 0 (illegal) f4xPe3
-8/8/2Q1N3/3B4/2PP1k2/3NQ2P/2P5/B2RK2R b K - ? 0 (illegal) f4xQe3
-8/8/2Q1N3/3B4/2PP1k2/3NR2P/2P5/B2RK2R b K - ? 0 (illegal) f4xRe3
-8/8/2Q1N3/3B4/2PP1k2/3NB2P/2P5/B2RK2R b K - ? 0 (illegal) f4xBe3
-8/8/2Q1N3/3B4/2PP1k2/3NN2P/2P5/B2RK2R b K - ? 0 (illegal) f4xNe3
-8/8/2Q1N3/3B4/2PPk3/3NP2P/2P5/B2RK2R b K - ? 0 (illegal) e4xPe3
-8/8/2Q1N3/3B4/2PPk3/3NQ2P/2P5/B2RK2R b K - ? 0 (illegal) e4xQe3
-8/8/2Q1N3/3B4/2PPk3/3NR2P/2P5/B2RK2R b K - ? 0 (illegal) e4xRe3
-8/8/2Q1N3/3B4/2PPk3/3NB2P/2P5/B2RK2R b K - ? 0 (illegal) e4xBe3
-8/8/2Q1N3/3B4/2PPk3/3NN2P/2P5/B2RK2R b K - ? 0 (illegal) e4xNe3
-8/8/2Q1N3/3B4/2PP4/3NPk1P/2P5/B2RK2R b K - ? 0 (illegal) f3xPe3
-8/8/2Q1N3/3B4/2PP4/3NQk1P/2P5/B2RK2R b K - ? 0 (illegal) f3xQe3
-8/8/2Q1N3/3B4/2PP4/3NRk1P/2P5/B2RK2R b K - ? 0 f3xRe3
-8/8/2Q1N3/3B4/2PP4/3NBk1P/2P5/B2RK2R b K - ? 0 (illegal) f3xBe3
-8/8/2Q1N3/3B4/2PP4/3NNk1P/2P5/B2RK2R b K - ? 0 (illegal) f3xNe3
-8/8/2Q1N3/3B4/2PP1k2/3N3P/2P5/B2RK2R b - - ? 0 (illegal) f4e3
-8/8/2Q1N3/3B4/2PPk3/3N3P/2P5/B2RK2R b - - ? 0 (illegal) e4e3
-8/8/2Q1N3/3B4/2PP4/3N1k1P/2P5/B2RK2R b - - ? 0 (illegal) f3e3
-8/8/2Q1N3/3B4/2PP1k2/3NP2P/2P5/B2RK2R b - - ? 0 (illegal) f4xPe3
-8/8/2Q1N3/3B4/2PP1k2/3NQ2P/2P5/B2RK2R b - - ? 0 (illegal) f4xQe3
-8/8/2Q1N3/3B4/2PP1k2/3NR2P/2P5/B2RK2R b - - ? 0 (illegal) f4xRe3
-8/8/2Q1N3/3B4/2PP1k2/3NB2P/2P5/B2RK2R b - - ? 0 (illegal) f4xBe3
-8/8/2Q1N3/3B4/2PP1k2/3NN2P/2P5/B2RK2R b - - ? 0 (illegal) f4xNe3
-8/8/2Q1N3/3B4/2PPk3/3NP2P/2P5/B2RK2R b - - ? 0 (illegal) e4xPe3
-8/8/2Q1N3/3B4/2PPk3/3NQ2P/2P5/B2RK2R b - - ? 0 (illegal) e4xQe3
-8/8/2Q1N3/3B4/2PPk3/3NR2P/2P5/B2RK2R b - - ? 0 (illegal) e4xRe3
-8/8/2Q1N3/3B4/2PPk3/3NB2P/2P5/B2RK2R b - - ? 0 (illegal) e4xBe3
-8/8/2Q1N3/3B4/2PPk3/3NN2P/2P5/B2RK2R b - - ? 0 (illegal) e4xNe3
-8/8/2Q1N3/3B4/2PP4/3NPk1P/2P5/B2RK2R b - - ? 0 (illegal) f3xPe3
-8/8/2Q1N3/3B4/2PP4/3NQk1P/2P5/B2RK2R b - - ? 0 (illegal) f3xQe3
-8/8/2Q1N3/3B4/2PP4/3NRk1P/2P5/B2RK2R b - - ? 0 (dead) f3xRe3
-8/8/2Q1N3/3B4/2PP4/3NBk1P/2P5/B2RK2R b - - ? 0 (illegal) f3xBe3
-8/8/2Q1N3/3B4/2PP4/3NNk1P/2P5/B2RK2R b - - ? 0 (illegal) f3xNe3
-nsols 1                                                                        
->>> 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= #2
-e1g1 ... #                                                                      
-nsols 1                                                                        
+nsols 1
+                                                                       
+>>> 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= #2 >>= legal
+e1g1 ... # 8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2R1RK1 b - - 1 1                       
+nsols 1
+                                                                       
 // 26 - P1284834 Andrew Buchanan & Joaquim Crusats 3 Problemas 5, p. 107, 1/2014
 >>> qqbqBqN1/brrnq1qq/Rnk1KRN1/3N1N2/1PP5/8/1Q3q2/B4q2 w >>= DP
-qqbqBqN1/brrnq1qq/Rnk1KRN1/3N1N2/1PP5/8/1Q3q2/B4q2 w - - ? 1 DP
-nsols 1                                                                        
+DP (explanation interrupted for being too long) qqbqBqN1/brrnq1qq/Rnk1KRN1/3N1N2/1PP5/8/1Q3q2/B4q2 w - - ? 1
+nsols 1
+                                                                       
 // 27 - P1284835 Joaquim Crusats & Andrew Buchanan 2 Problemas 5, p. 107, 1/2014
 >>> qqb1B3/qqrn4/qqkqR3/brnqPKP1/1p2BNN1/1P3P2/8/2R5 b >>= DP
-qqb1B3/qqrn4/qqkqR3/brnqPKP1/1p2BNN1/1P3P2/8/2R5 b - - ? 1 DP
-nsols 1                                                                        
+DP (d6e6 (d5e4 f3e4 d6e6 f4e6=) f4e6 d5e4 f3e4=) qqb1B3/qqrn4/qqkqR3/brnqPKP1/1p2BNN1/1P3P2/8/2R5 b - - ? 1
+nsols 1
+                                                                       
 // 28 - P1298521 Mrs. W. J. Baird British Chess Magazine 1906
->>> 5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p3p1/8 b >>= r >>= h#1.5
-b1xNb3 then c5e7 f3d5 b1e1#                                                     
-nsols 1                                                                        
->>> 5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p1p3/8 b >>= r >>= h#1.5
-g2g3 then c5d6 e5e4 g2f3#                                                       
-nsols 1                                                                        
+>>> 5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p3p1/8 b >>= r >>= h#1.5 >>= legal
+↶b1xNb3 c5e7 f3d5 b1e1# 5n2/b3B3/8/1R1bkp2/3p4/1n4P1/K1p3p1/1R6 w - - 0 2       
+nsols 1
+                                                                       
+>>> 5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p1p3/8 b >>= r >>= h#1.5 >>= legal
+↶g2g3 c5d6 e5e4 g2f3# 5n2/b7/3B4/1R1P1p2/3pk3/1R3b2/K1p1p1P1/8 w - - 2 2        
+nsols 1
+                                                                       
 // 29 - P1300674 Per Olin 1 Problemas 10, p. 241, 04/2015
 // 30 - P1300675 Andrew Buchanan 2 Problemas 10, p. 241, 04/2015
 // 31 - P1300677 Per Olin 4v Problemas 10, p. 241, 04/2015
@@ -392,262 +419,267 @@ nsols 1
 // 34 - P1324768 Per Olin 5v Problemas 13, p. 331, 1/2016
 // 35 - P1324769 Andrey Frolkin & Per Olin 3v2 Problemas 13, p. 331, 1/2016
 // 36 - P1338362 Andrew Buchanan 2 Problemas 18, p. 487, 04/2017
->>> 8/5p2/5P2/8/1p6/kP2pp2/1pKpP3/3B4 w >>= r >>= h=1
-e4f3ep then b2b1q DP ×                                                          
-e4f3ep then b2b1r c2b1 stalemate                                                
-e4f3ep then b2b1b DP ×                                                          
-e4f3ep then b2b1n DP ×                                                          
-nsols 1                                                                        
+>>> 8/5p2/5P2/8/1p6/kP2pp2/1pKpP3/3B4 w >>= r >>= h=1 >>= legal
+↶e4f3ep b2b1q dead (c2b1=) 8/5p2/5P2/8/1p2pP2/kP2p3/2KpP3/1q1B4 w - - 0 2       
+↶e4f3ep b2b1r c2b1 (living alternative f4f5 b1c1#) stalemate 8/5p2/5P2/8/1p2pP2/kP2p3/2KpP3/1r1B4 w - - 0 2
+↶e4f3ep b2b1b dead (c2b1=) 8/5p2/5P2/8/1p2pP2/kP2p3/2KpP3/1b1B4 w - - 0 2       
+↶e4f3ep b2b1n dead (c2b1= (f4f5 a3a2= (b1c3 =))) 8/5p2/5P2/8/1p2pP2/kP2p3/2KpP3/1n1B4 w - - 0 2
+nsols 4
+                                                                       
 // 37 - P1345823 Andrew Buchanan 6 Problemas 20, p. 553, 10/2017 Article 15
 >>> 8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 ? >>= legal
-8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 w - - ? 1 
-8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 b - - ? 1 
-nsols 2                                                                        
->>> 8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 w >>= h=1.5
-b1a2 DP ×                                                                       
-a5a6 a2b1q DP ×                                                                 
-a5a6 a2b1r c2b1 stalemate                                                       
-a5a6 a2b1b DP ×                                                                 
-a5a6 a2b1n DP ×                                                                 
-nsols 1                                                                        
+8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 w - - ? 1                                 
+8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 b - - ? 1                                 
+nsols 2
+                                                                       
+>>> 8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 w >>= h=1.5 >>= legal
+a5a6 a2b1q dead (c2b1=) 8/p7/P7/3p4/Pp1p4/kP1Pp3/2KpP3/Nq1B4 w - - 0 2          
+a5a6 a2b1r c2b1 (living alternative a4a5 b1c1#) stalemate 8/p7/P7/3p4/Pp1p4/kP1Pp3/2KpP3/Nr1B4 w - - 0 2
+a5a6 a2b1b dead (c2b1=) 8/p7/P7/3p4/Pp1p4/kP1Pp3/2KpP3/Nb1B4 w - - 0 2          
+a5a6 a2b1n dead (c2b1= (a4a5 a3a2= (b1c3 =))) 8/p7/P7/3p4/Pp1p4/kP1Pp3/2KpP3/Nn1B4 w - - 0 2
+nsols 4
+                                                                       
 // 38 - P1368543 Per Olin & Andrew Buchanan Springaren 149, p. 4, 03/2019
 // 39 - P1404973 Per Olin Springaren 2021 Commendation Springaren Summer Competition 2021 c cooked & how about D?
 // 40 - P1405799 Mrs. W. J. Baird & Andrew Buchanan PDB Website 13/11/2022 WJB, correction AB 4 solutions
 // 41 - P1408993 Andrew Buchanan 24 A Practical Algorithm for Chess Unwinnability 2022
->>> 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbK5 b >>= r
-8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kb1K4 w - - ? 1 (illegal) d1c1
-8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbqK4 w - - ? 1 (illegal) d1xQc1
-8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbrK4 w - - ? 1 (illegal) d1xRc1
-8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbbK4 w - - ? 1 (illegal) d1xBc1
-8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbnK4 w - - ? 1 (illegal) d1xNc1
-8/8/2p5/pP6/P1p5/PpPp4/brpP4/kbK5 w - - ? 1 (dead) b5b6
-8/8/2p5/pP6/P1p5/PpPp4/brpP4/kbK5 w - a6 0 1 (dead) b5b6
-8/8/1pp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1 (dead) c5xPb6
-8/8/1qp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1 (dead) c5xQb6
-8/8/1rp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1 (dead) c5xRb6
-8/8/1bp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1 (dead) c5xBb6
-8/8/1np5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1 (dead) c5xNb6
-8/8/2p5/ppP5/P1p5/PpPp4/brpP4/kbK5 w - b6 0 1 c5b6ep
-nsols 1                                                                        
+>>> 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbK5 b >>= r >>= legal
+↶d1c1 illegal 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kb1K4 w - - ? 1                      
+↶d1xQc1 illegal dead 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbqK4 w - - ? 1               
+↶d1xRc1 illegal dead 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbrK4 w - - ? 1               
+↶d1xBc1 illegal 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbbK4 w - - ? 1                    
+↶d1xNc1 illegal 8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbnK4 w - - ? 1                    
+↶b5b6 dead 8/8/2p5/pP6/P1p5/PpPp4/brpP4/kbK5 w - - ? 1                          
+↶b5b6 dead 8/8/2p5/pP6/P1p5/PpPp4/brpP4/kbK5 w - a6 0 1                         
+↶c5xPb6 dead 8/8/1pp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1                      
+↶c5xQb6 dead 8/8/1qp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1                      
+↶c5xRb6 dead 8/8/1rp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1                      
+↶c5xBb6 dead 8/8/1bp5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1                      
+↶c5xNb6 dead 8/8/1np5/p1P5/P1p5/PpPp4/brpP4/kbK5 w - - ? 1                      
+↶c5b6ep 8/8/2p5/ppP5/P1p5/PpPp4/brpP4/kbK5 w - b6 0 1                           
+nsols 1
+                                                                       
 // 42 - P1408994 Andrey Frolkin & Andrew Buchanan 25 A Practical Algorithm for Chess Unwinnability 2022
->>> 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 ? >>= r
-8/1kPN4/PP1PB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0 b7c6
-8/2PN4/PP1PB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) d5c6
-8/2PN4/PP1PB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) c5c6
-8/1kPN4/PPPPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) b7xPc6
-8/1kPN4/PPQPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) b7xQc6
-8/1kPN4/PPRPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0 b7xRc6
-8/1kPN4/PPBPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) b7xBc6
-8/1kPN4/PPNPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0 b7xNc6
-8/2PN4/PPPPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) d5xPc6
-8/2PN4/PPQPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) d5xQc6
-8/2PN4/PPRPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) d5xRc6
-8/2PN4/PPBPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) d5xBc6
-8/2PN4/PPNPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) d5xNc6
-8/2PN4/PPPPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) c5xPc6
-8/2PN4/PPQPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) c5xQc6
-8/2PN4/PPRPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) c5xRc6
-8/2PN4/PPBPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) c5xBc6
-8/2PN4/PPNPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0 (illegal) c5xNc6
-8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P6/8 w - - ? 1 e3e2
-8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P6/8 w - - ? 1 e4e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P6/4R3 w - - ? 1 e1e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P3R2/8 w - - ? 1 f2e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P4R1/8 w - - ? 1 g2e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P5R/8 w - - ? 1 h2e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1R4/8 w - - ? 1 d2e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR5/8 w - - ? 1 c2e2
-8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2p3/8 w - - ? 1 e3xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2q3/8 w - - ? 1 e3xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2r3/8 w - - ? 1 e3xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2b3/8 w - - ? 1 e3xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2n3/8 w - - ? 1 e3xNe2
-8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2p3/8 w - - ? 1 e4xPe2
-8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2q3/8 w - - ? 1 e4xQe2
-8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2r3/8 w - - ? 1 e4xRe2
-8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2b3/8 w - - ? 1 e4xBe2
-8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2n3/8 w - - ? 1 e4xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2p3/4R3 w - - ? 1 e1xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2q3/4R3 w - - ? 1 e1xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2r3/4R3 w - - ? 1 e1xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2b3/4R3 w - - ? 1 e1xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2n3/4R3 w - - ? 1 e1xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2pR2/8 w - - ? 1 f2xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2qR2/8 w - - ? 1 f2xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2rR2/8 w - - ? 1 f2xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2bR2/8 w - - ? 1 f2xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2nR2/8 w - - ? 1 f2xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2p1R1/8 w - - ? 1 g2xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2q1R1/8 w - - ? 1 g2xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2r1R1/8 w - - ? 1 g2xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2b1R1/8 w - - ? 1 g2xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2n1R1/8 w - - ? 1 g2xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2p2R/8 w - - ? 1 h2xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2q2R/8 w - - ? 1 h2xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2r2R/8 w - - ? 1 h2xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2b2R/8 w - - ? 1 h2xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2n2R/8 w - - ? 1 h2xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rp3/8 w - - ? 1 d2xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rq3/8 w - - ? 1 d2xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rr3/8 w - - ? 1 d2xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rb3/8 w - - ? 1 d2xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rn3/8 w - - ? 1 d2xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1p3/8 w - - ? 1 c2xPe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1q3/8 w - - ? 1 c2xQe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1r3/8 w - - ? 1 c2xRe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1b3/8 w - - ? 1 c2xBe2
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1n3/8 w - - ? 1 c2xNe2
-8/2PN4/PPkPB3/K3B3/NPP5/3P4/1PR1R3/8 w - - ? 1 c2c3
-8/2PN4/PPkPB3/K3B3/NPP5/3P4/1P2R3/2R5 w - - ? 1 c1c3
-8/2PN4/PPkPB3/K3B3/NPP5/1R1P4/1P2R3/8 w - - ? 1 b3c3
-8/2PN4/PPkPB3/K3B3/NPP5/R2P4/1P2R3/8 w - - ? 1 a3c3
-8/2PN4/PPkPB3/K3B3/NPP5/2pP4/1PR1R3/8 w - - ? 1 c2xPc3
-8/2PN4/PPkPB3/K3B3/NPP5/2qP4/1PR1R3/8 w - - ? 1 c2xQc3
-8/2PN4/PPkPB3/K3B3/NPP5/2rP4/1PR1R3/8 w - - ? 1 c2xRc3
-8/2PN4/PPkPB3/K3B3/NPP5/2bP4/1PR1R3/8 w - - ? 1 c2xBc3
-8/2PN4/PPkPB3/K3B3/NPP5/2nP4/1PR1R3/8 w - - ? 1 c2xNc3
-8/2PN4/PPkPB3/K3B3/NPP5/2pP4/1P2R3/2R5 w - - ? 1 c1xPc3
-8/2PN4/PPkPB3/K3B3/NPP5/2qP4/1P2R3/2R5 w - - ? 1 c1xQc3
-8/2PN4/PPkPB3/K3B3/NPP5/2rP4/1P2R3/2R5 w - - ? 1 c1xRc3
-8/2PN4/PPkPB3/K3B3/NPP5/2bP4/1P2R3/2R5 w - - ? 1 c1xBc3
-8/2PN4/PPkPB3/K3B3/NPP5/2nP4/1P2R3/2R5 w - - ? 1 c1xNc3
-8/2PN4/PPkPB3/K3B3/NPP5/1RpP4/1P2R3/8 w - - ? 1 b3xPc3
-8/2PN4/PPkPB3/K3B3/NPP5/1RqP4/1P2R3/8 w - - ? 1 b3xQc3
-8/2PN4/PPkPB3/K3B3/NPP5/1RrP4/1P2R3/8 w - - ? 1 b3xRc3
-8/2PN4/PPkPB3/K3B3/NPP5/1RbP4/1P2R3/8 w - - ? 1 b3xBc3
-8/2PN4/PPkPB3/K3B3/NPP5/1RnP4/1P2R3/8 w - - ? 1 b3xNc3
-8/2PN4/PPkPB3/K3B3/NPP5/R1pP4/1P2R3/8 w - - ? 1 a3xPc3
-8/2PN4/PPkPB3/K3B3/NPP5/R1qP4/1P2R3/8 w - - ? 1 a3xQc3
-8/2PN4/PPkPB3/K3B3/NPP5/R1rP4/1P2R3/8 w - - ? 1 a3xRc3
-8/2PN4/PPkPB3/K3B3/NPP5/R1bP4/1P2R3/8 w - - ? 1 a3xBc3
-8/2PN4/PPkPB3/K3B3/NPP5/R1nP4/1P2R3/8 w - - ? 1 a3xNc3
-8/2PN4/PPkPB3/K3B3/NPP5/2R5/1P1PR3/8 w - - ? 1 d2d3
-8/2PN4/PPkPB3/K3B3/NPP5/2Rp4/1PP1R3/8 w - - ? 1 c2xPd3
-8/2PN4/PPkPB3/K3B3/NPP5/2Rq4/1PP1R3/8 w - - ? 1 c2xQd3
-8/2PN4/PPkPB3/K3B3/NPP5/2Rr4/1PP1R3/8 w - - ? 1 c2xRd3
-8/2PN4/PPkPB3/K3B3/NPP5/2Rb4/1PP1R3/8 w - - ? 1 c2xBd3
-8/2PN4/PPkPB3/K3B3/NPP5/2Rn4/1PP1R3/8 w - - ? 1 c2xNd3
-8/2PN4/PPkPB3/K1N1B3/1PP5/2RP4/1P2R3/8 w - - ? 1 c5a4
-8/2PN4/PPkPB3/K1N1B3/pPP5/2RP4/1P2R3/8 w - - ? 1 c5xPa4
-8/2PN4/PPkPB3/K1N1B3/qPP5/2RP4/1P2R3/8 w - - ? 1 (dead) c5xQa4
-8/2PN4/PPkPB3/K1N1B3/rPP5/2RP4/1P2R3/8 w - - ? 1 (dead) c5xRa4
-8/2PN4/PPkPB3/K1N1B3/bPP5/2RP4/1P2R3/8 w - - ? 1 c5xBa4
-8/2PN4/PPkPB3/K1N1B3/nPP5/2RP4/1P2R3/8 w - - ? 1 c5xNa4
-8/2PN4/PPkPB3/K3B3/N1P5/1PRP4/1P2R3/8 w - - ? 1 b3b4
-8/2PN4/PPkPB3/K3B3/NpP5/P1RP4/1P2R3/8 w - - ? 1 a3xPb4
-8/2PN4/PPkPB3/K3B3/NqP5/P1RP4/1P2R3/8 w - - ? 1 (dead) a3xQb4
-8/2PN4/PPkPB3/K3B3/NrP5/P1RP4/1P2R3/8 w - - ? 1 a3xRb4
-8/2PN4/PPkPB3/K3B3/NbP5/P1RP4/1P2R3/8 w - - ? 1 (dead) a3xBb4
-8/2PN4/PPkPB3/K3B3/NnP5/P1RP4/1P2R3/8 w - - ? 1 a3xNb4
-8/2PN4/PPkPB3/K3B3/NPp5/1PRP4/1P2R3/8 w - - ? 1 b3xPc4
-8/2PN4/PPkPB3/K3B3/NPq5/1PRP4/1P2R3/8 w - - ? 1 b3xQc4
-8/2PN4/PPkPB3/K3B3/NPr5/1PRP4/1P2R3/8 w - - ? 1 b3xRc4
-8/2PN4/PPkPB3/K3B3/NPb5/1PRP4/1P2R3/8 w - - ? 1 b3xBc4
-8/2PN4/PPkPB3/K3B3/NPn5/1PRP4/1P2R3/8 w - - ? 1 b3xNc4
-8/2PN4/PPkPBB2/K7/NPP5/2RP4/1P2R3/8 w - - ? 1 f6e5
-8/2PN2B1/PPkPB3/K7/NPP5/2RP4/1P2R3/8 w - - ? 1 g7e5
-7B/2PN4/PPkPB3/K7/NPP5/2RP4/1P2R3/8 w - - ? 1 h8e5
-8/2PN4/PPkPB3/K7/NPP2B2/2RP4/1P2R3/8 w - - ? 1 f4e5
-8/2PN4/PPkPB3/K7/NPP5/2RP2B1/1P2R3/8 w - - ? 1 g3e5
-8/2PN4/PPkPB3/K7/NPP5/2RP4/1P2R2B/8 w - - ? 1 h2e5
-8/2PN4/PPkPB3/K7/NPPB4/2RP4/1P2R3/8 w - - ? 1 d4e5
-8/2PN4/PPkPBB2/K3p3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xPe5
-8/2PN4/PPkPBB2/K3q3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xQe5
-8/2PN4/PPkPBB2/K3r3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xRe5
-8/2PN4/PPkPBB2/K3b3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xBe5
-8/2PN4/PPkPBB2/K3n3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xNe5
-8/2PN2B1/PPkPB3/K3p3/NPP5/2RP4/1P2R3/8 w - - ? 1 g7xPe5
-8/2PN2B1/PPkPB3/K3q3/NPP5/2RP4/1P2R3/8 w - - ? 1 g7xQe5
-8/2PN2B1/PPkPB3/K3r3/NPP5/2RP4/1P2R3/8 w - - ? 1 g7xRe5
-8/2PN2B1/PPkPB3/K3b3/NPP5/2RP4/1P2R3/8 w - - ? 1 g7xBe5
-8/2PN2B1/PPkPB3/K3n3/NPP5/2RP4/1P2R3/8 w - - ? 1 g7xNe5
-7B/2PN4/PPkPB3/K3p3/NPP5/2RP4/1P2R3/8 w - - ? 1 h8xPe5
-7B/2PN4/PPkPB3/K3q3/NPP5/2RP4/1P2R3/8 w - - ? 1 h8xQe5
-7B/2PN4/PPkPB3/K3r3/NPP5/2RP4/1P2R3/8 w - - ? 1 h8xRe5
-7B/2PN4/PPkPB3/K3b3/NPP5/2RP4/1P2R3/8 w - - ? 1 h8xBe5
-7B/2PN4/PPkPB3/K3n3/NPP5/2RP4/1P2R3/8 w - - ? 1 h8xNe5
-8/2PN4/PPkPB3/K3p3/NPP2B2/2RP4/1P2R3/8 w - - ? 1 f4xPe5
-8/2PN4/PPkPB3/K3q3/NPP2B2/2RP4/1P2R3/8 w - - ? 1 f4xQe5
-8/2PN4/PPkPB3/K3r3/NPP2B2/2RP4/1P2R3/8 w - - ? 1 f4xRe5
-8/2PN4/PPkPB3/K3b3/NPP2B2/2RP4/1P2R3/8 w - - ? 1 f4xBe5
-8/2PN4/PPkPB3/K3n3/NPP2B2/2RP4/1P2R3/8 w - - ? 1 f4xNe5
-8/2PN4/PPkPB3/K3p3/NPP5/2RP2B1/1P2R3/8 w - - ? 1 g3xPe5
-8/2PN4/PPkPB3/K3q3/NPP5/2RP2B1/1P2R3/8 w - - ? 1 g3xQe5
-8/2PN4/PPkPB3/K3r3/NPP5/2RP2B1/1P2R3/8 w - - ? 1 g3xRe5
-8/2PN4/PPkPB3/K3b3/NPP5/2RP2B1/1P2R3/8 w - - ? 1 g3xBe5
-8/2PN4/PPkPB3/K3n3/NPP5/2RP2B1/1P2R3/8 w - - ? 1 g3xNe5
-8/2PN4/PPkPB3/K3p3/NPP5/2RP4/1P2R2B/8 w - - ? 1 h2xPe5
-8/2PN4/PPkPB3/K3q3/NPP5/2RP4/1P2R2B/8 w - - ? 1 h2xQe5
-8/2PN4/PPkPB3/K3r3/NPP5/2RP4/1P2R2B/8 w - - ? 1 h2xRe5
-8/2PN4/PPkPB3/K3b3/NPP5/2RP4/1P2R2B/8 w - - ? 1 h2xBe5
-8/2PN4/PPkPB3/K3n3/NPP5/2RP4/1P2R2B/8 w - - ? 1 h2xNe5
-8/2PN4/PPkPB3/K3p3/NPPB4/2RP4/1P2R3/8 w - - ? 1 d4xPe5
-8/2PN4/PPkPB3/K3q3/NPPB4/2RP4/1P2R3/8 w - - ? 1 d4xQe5
-8/2PN4/PPkPB3/K3r3/NPPB4/2RP4/1P2R3/8 w - - ? 1 d4xRe5
-8/2PN4/PPkPB3/K3b3/NPPB4/2RP4/1P2R3/8 w - - ? 1 d4xBe5
-8/2PN4/PPkPB3/K3n3/NPPB4/2RP4/1P2R3/8 w - - ? 1 d4xNe5
-8/2PN4/PpkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 (dead) c5xPb6
-8/2PN4/PqkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 (dead) c5xQb6
-8/2PN4/PrkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xRb6
-8/2PN4/PbkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 (dead) c5xBb6
-8/2PN4/PnkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xNb6
-8/2PN4/P1kPB3/KpP1B3/NPP5/2RP4/1P2R3/8 w - b6 0 1 c5b6ep
-8/2PN4/PPkpB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xPd6
-8/2PN4/PPkqB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xQd6
-8/2PN4/PPkrB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xRd6
-8/2PN4/PPkbB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xBd6
-8/2PN4/PPknB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xNd6
-8/2PN1B2/PPkP4/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f7e6
-6B1/2PN4/PPkP4/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 g8e6
-8/2PN4/PPkP4/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1 f5e6
-8/2PN4/PPkP4/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1 g4e6
-8/2PN4/PPkP4/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1 h3e6
-8/2PN1B2/PPkPp3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f7xPe6
-8/2PN1B2/PPkPq3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f7xQe6
-8/2PN1B2/PPkPr3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f7xRe6
-8/2PN1B2/PPkPb3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f7xBe6
-8/2PN1B2/PPkPn3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f7xNe6
-6B1/2PN4/PPkPp3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 g8xPe6
-6B1/2PN4/PPkPq3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 g8xQe6
-6B1/2PN4/PPkPr3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 g8xRe6
-6B1/2PN4/PPkPb3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 g8xBe6
-6B1/2PN4/PPkPn3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 g8xNe6
-8/2PN4/PPkPp3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1 f5xPe6
-8/2PN4/PPkPq3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1 f5xQe6
-8/2PN4/PPkPr3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1 f5xRe6
-8/2PN4/PPkPb3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1 f5xBe6
-8/2PN4/PPkPn3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1 f5xNe6
-8/2PN4/PPkPp3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1 g4xPe6
-8/2PN4/PPkPq3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1 g4xQe6
-8/2PN4/PPkPr3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1 g4xRe6
-8/2PN4/PPkPb3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1 g4xBe6
-8/2PN4/PPkPn3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1 g4xNe6
-8/2PN4/PPkPp3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1 h3xPe6
-8/2PN4/PPkPq3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1 h3xQe6
-8/2PN4/PPkPr3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1 h3xRe6
-8/2PN4/PPkPb3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1 h3xBe6
-8/2PN4/PPkPn3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1 h3xNe6
-5N2/2P5/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f8d7
-8/2P5/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6d7
-8/2P5/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5d7
-5N2/2Pp4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f8xPd7
-5N2/2Pq4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f8xQd7
-5N2/2Pr4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f8xRd7
-5N2/2Pb4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f8xBd7
-5N2/2Pn4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f8xNd7
-8/2Pp4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xPd7
-8/2Pq4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xQd7
-8/2Pr4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xRd7
-8/2Pb4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xBd7
-8/2Pn4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1 f6xNd7
-8/2Pp4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xPd7
-8/2Pq4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xQd7
-8/2Pr4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xRd7
-8/2Pb4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xBd7
-8/2Pn4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1 c5xNd7
-nsols 192                                                                        
+>>> 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 ? >>= r >>= legal
+↶b7c6 8/1kPN4/PP1PB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0                           
+↶d5c6 illegal 8/2PN4/PP1PB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0                   
+↶c5c6 illegal 8/2PN4/PP1PB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0                  
+↶b7xPc6 illegal 8/1kPN4/PPPPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶b7xQc6 illegal 8/1kPN4/PPQPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶b7xRc6 8/1kPN4/PPRPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0                         
+↶b7xBc6 illegal 8/1kPN4/PPBPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶b7xNc6 8/1kPN4/PPNPB3/K3B3/NPP5/2RP4/1P2R3/8 b - - ? 0                         
+↶d5xPc6 illegal 8/2PN4/PPPPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶d5xQc6 illegal 8/2PN4/PPQPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶d5xRc6 illegal 8/2PN4/PPRPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶d5xBc6 illegal 8/2PN4/PPBPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶d5xNc6 illegal 8/2PN4/PPNPB3/K2kB3/NPP5/2RP4/1P2R3/8 b - - ? 0                 
+↶c5xPc6 illegal 8/2PN4/PPPPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0                
+↶c5xQc6 illegal 8/2PN4/PPQPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0                
+↶c5xRc6 illegal 8/2PN4/PPRPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0                
+↶c5xBc6 illegal 8/2PN4/PPBPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0                
+↶c5xNc6 illegal 8/2PN4/PPNPB3/K1k1B3/NPP5/2RP4/1P2R3/8 b - - ? 0                
+↶e3e2 8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P6/8 w - - ? 1                             
+↶e4e2 8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P6/8 w - - ? 1                            
+↶e1e2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P6/4R3 w - - ? 1                            
+↶f2e2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P3R2/8 w - - ? 1                            
+↶g2e2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P4R1/8 w - - ? 1                            
+↶h2e2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P5R/8 w - - ? 1                             
+↶d2e2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1R4/8 w - - ? 1                            
+↶c2e2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR5/8 w - - ? 1                             
+↶e3xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2p3/8 w - - ? 1                         
+↶e3xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2q3/8 w - - ? 1                         
+↶e3xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2r3/8 w - - ? 1                         
+↶e3xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2b3/8 w - - ? 1                         
+↶e3xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RPR3/1P2n3/8 w - - ? 1                         
+↶e4xPe2 8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2p3/8 w - - ? 1                        
+↶e4xQe2 8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2q3/8 w - - ? 1                        
+↶e4xRe2 8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2r3/8 w - - ? 1                        
+↶e4xBe2 8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2b3/8 w - - ? 1                        
+↶e4xNe2 8/2PN4/PPkPB3/K3B3/NPP1R3/2RP4/1P2n3/8 w - - ? 1                        
+↶e1xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2p3/4R3 w - - ? 1                        
+↶e1xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2q3/4R3 w - - ? 1                        
+↶e1xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2r3/4R3 w - - ? 1                        
+↶e1xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2b3/4R3 w - - ? 1                        
+↶e1xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2n3/4R3 w - - ? 1                        
+↶f2xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2pR2/8 w - - ? 1                         
+↶f2xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2qR2/8 w - - ? 1                         
+↶f2xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2rR2/8 w - - ? 1                         
+↶f2xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2bR2/8 w - - ? 1                         
+↶f2xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2nR2/8 w - - ? 1                         
+↶g2xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2p1R1/8 w - - ? 1                        
+↶g2xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2q1R1/8 w - - ? 1                        
+↶g2xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2r1R1/8 w - - ? 1                        
+↶g2xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2b1R1/8 w - - ? 1                        
+↶g2xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2n1R1/8 w - - ? 1                        
+↶h2xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2p2R/8 w - - ? 1                         
+↶h2xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2q2R/8 w - - ? 1                         
+↶h2xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2r2R/8 w - - ? 1                         
+↶h2xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2b2R/8 w - - ? 1                         
+↶h2xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2n2R/8 w - - ? 1                         
+↶d2xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rp3/8 w - - ? 1                         
+↶d2xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rq3/8 w - - ? 1                         
+↶d2xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rr3/8 w - - ? 1                         
+↶d2xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rb3/8 w - - ? 1                         
+↶d2xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P1Rn3/8 w - - ? 1                         
+↶c2xPe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1p3/8 w - - ? 1                         
+↶c2xQe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1q3/8 w - - ? 1                         
+↶c2xRe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1r3/8 w - - ? 1                         
+↶c2xBe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1b3/8 w - - ? 1                         
+↶c2xNe2 8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1PR1n3/8 w - - ? 1                         
+↶c2c3 8/2PN4/PPkPB3/K3B3/NPP5/3P4/1PR1R3/8 w - - ? 1                            
+↶c1c3 8/2PN4/PPkPB3/K3B3/NPP5/3P4/1P2R3/2R5 w - - ? 1                           
+↶b3c3 8/2PN4/PPkPB3/K3B3/NPP5/1R1P4/1P2R3/8 w - - ? 1                           
+↶a3c3 8/2PN4/PPkPB3/K3B3/NPP5/R2P4/1P2R3/8 w - - ? 1                            
+↶c2xPc3 8/2PN4/PPkPB3/K3B3/NPP5/2pP4/1PR1R3/8 w - - ? 1                         
+↶c2xQc3 8/2PN4/PPkPB3/K3B3/NPP5/2qP4/1PR1R3/8 w - - ? 1                         
+↶c2xRc3 8/2PN4/PPkPB3/K3B3/NPP5/2rP4/1PR1R3/8 w - - ? 1                         
+↶c2xBc3 8/2PN4/PPkPB3/K3B3/NPP5/2bP4/1PR1R3/8 w - - ? 1                         
+↶c2xNc3 8/2PN4/PPkPB3/K3B3/NPP5/2nP4/1PR1R3/8 w - - ? 1                         
+↶c1xPc3 8/2PN4/PPkPB3/K3B3/NPP5/2pP4/1P2R3/2R5 w - - ? 1                        
+↶c1xQc3 8/2PN4/PPkPB3/K3B3/NPP5/2qP4/1P2R3/2R5 w - - ? 1                        
+↶c1xRc3 8/2PN4/PPkPB3/K3B3/NPP5/2rP4/1P2R3/2R5 w - - ? 1                        
+↶c1xBc3 8/2PN4/PPkPB3/K3B3/NPP5/2bP4/1P2R3/2R5 w - - ? 1                        
+↶c1xNc3 8/2PN4/PPkPB3/K3B3/NPP5/2nP4/1P2R3/2R5 w - - ? 1                        
+↶b3xPc3 8/2PN4/PPkPB3/K3B3/NPP5/1RpP4/1P2R3/8 w - - ? 1                         
+↶b3xQc3 8/2PN4/PPkPB3/K3B3/NPP5/1RqP4/1P2R3/8 w - - ? 1                         
+↶b3xRc3 8/2PN4/PPkPB3/K3B3/NPP5/1RrP4/1P2R3/8 w - - ? 1                         
+↶b3xBc3 8/2PN4/PPkPB3/K3B3/NPP5/1RbP4/1P2R3/8 w - - ? 1                         
+↶b3xNc3 8/2PN4/PPkPB3/K3B3/NPP5/1RnP4/1P2R3/8 w - - ? 1                         
+↶a3xPc3 8/2PN4/PPkPB3/K3B3/NPP5/R1pP4/1P2R3/8 w - - ? 1                         
+↶a3xQc3 8/2PN4/PPkPB3/K3B3/NPP5/R1qP4/1P2R3/8 w - - ? 1                         
+↶a3xRc3 8/2PN4/PPkPB3/K3B3/NPP5/R1rP4/1P2R3/8 w - - ? 1                         
+↶a3xBc3 8/2PN4/PPkPB3/K3B3/NPP5/R1bP4/1P2R3/8 w - - ? 1                         
+↶a3xNc3 8/2PN4/PPkPB3/K3B3/NPP5/R1nP4/1P2R3/8 w - - ? 1                         
+↶d2d3 8/2PN4/PPkPB3/K3B3/NPP5/2R5/1P1PR3/8 w - - ? 1                            
+↶c2xPd3 8/2PN4/PPkPB3/K3B3/NPP5/2Rp4/1PP1R3/8 w - - ? 1                         
+↶c2xQd3 8/2PN4/PPkPB3/K3B3/NPP5/2Rq4/1PP1R3/8 w - - ? 1                         
+↶c2xRd3 8/2PN4/PPkPB3/K3B3/NPP5/2Rr4/1PP1R3/8 w - - ? 1                         
+↶c2xBd3 8/2PN4/PPkPB3/K3B3/NPP5/2Rb4/1PP1R3/8 w - - ? 1                         
+↶c2xNd3 8/2PN4/PPkPB3/K3B3/NPP5/2Rn4/1PP1R3/8 w - - ? 1                         
+↶c5a4 illegal 8/2PN4/PPkPB3/K1N1B3/1PP5/2RP4/1P2R3/8 w - - ? 1                  
+↶c5xPa4 8/2PN4/PPkPB3/K1N1B3/pPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xQa4 dead 8/2PN4/PPkPB3/K1N1B3/qPP5/2RP4/1P2R3/8 w - - ? 1                   
+↶c5xRa4 dead 8/2PN4/PPkPB3/K1N1B3/rPP5/2RP4/1P2R3/8 w - - ? 1                   
+↶c5xBa4 8/2PN4/PPkPB3/K1N1B3/bPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xNa4 illegal 8/2PN4/PPkPB3/K1N1B3/nPP5/2RP4/1P2R3/8 w - - ? 1                
+↶b3b4 8/2PN4/PPkPB3/K3B3/N1P5/1PRP4/1P2R3/8 w - - ? 1                           
+↶a3xPb4 8/2PN4/PPkPB3/K3B3/NpP5/P1RP4/1P2R3/8 w - - ? 1                         
+↶a3xQb4 dead 8/2PN4/PPkPB3/K3B3/NqP5/P1RP4/1P2R3/8 w - - ? 1                    
+↶a3xRb4 8/2PN4/PPkPB3/K3B3/NrP5/P1RP4/1P2R3/8 w - - ? 1                         
+↶a3xBb4 dead 8/2PN4/PPkPB3/K3B3/NbP5/P1RP4/1P2R3/8 w - - ? 1                    
+↶a3xNb4 8/2PN4/PPkPB3/K3B3/NnP5/P1RP4/1P2R3/8 w - - ? 1                         
+↶b3xPc4 8/2PN4/PPkPB3/K3B3/NPp5/1PRP4/1P2R3/8 w - - ? 1                         
+↶b3xQc4 8/2PN4/PPkPB3/K3B3/NPq5/1PRP4/1P2R3/8 w - - ? 1                         
+↶b3xRc4 8/2PN4/PPkPB3/K3B3/NPr5/1PRP4/1P2R3/8 w - - ? 1                         
+↶b3xBc4 8/2PN4/PPkPB3/K3B3/NPb5/1PRP4/1P2R3/8 w - - ? 1                         
+↶b3xNc4 8/2PN4/PPkPB3/K3B3/NPn5/1PRP4/1P2R3/8 w - - ? 1                         
+↶f6e5 8/2PN4/PPkPBB2/K7/NPP5/2RP4/1P2R3/8 w - - ? 1                             
+↶g7e5 8/2PN2B1/PPkPB3/K7/NPP5/2RP4/1P2R3/8 w - - ? 1                            
+↶h8e5 7B/2PN4/PPkPB3/K7/NPP5/2RP4/1P2R3/8 w - - ? 1                             
+↶f4e5 8/2PN4/PPkPB3/K7/NPP2B2/2RP4/1P2R3/8 w - - ? 1                            
+↶g3e5 8/2PN4/PPkPB3/K7/NPP5/2RP2B1/1P2R3/8 w - - ? 1                            
+↶h2e5 8/2PN4/PPkPB3/K7/NPP5/2RP4/1P2R2B/8 w - - ? 1                             
+↶d4e5 8/2PN4/PPkPB3/K7/NPPB4/2RP4/1P2R3/8 w - - ? 1                             
+↶f6xPe5 8/2PN4/PPkPBB2/K3p3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xQe5 8/2PN4/PPkPBB2/K3q3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xRe5 8/2PN4/PPkPBB2/K3r3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xBe5 8/2PN4/PPkPBB2/K3b3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xNe5 8/2PN4/PPkPBB2/K3n3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶g7xPe5 8/2PN2B1/PPkPB3/K3p3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g7xQe5 8/2PN2B1/PPkPB3/K3q3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g7xRe5 8/2PN2B1/PPkPB3/K3r3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g7xBe5 8/2PN2B1/PPkPB3/K3b3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g7xNe5 8/2PN2B1/PPkPB3/K3n3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶h8xPe5 7B/2PN4/PPkPB3/K3p3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶h8xQe5 7B/2PN4/PPkPB3/K3q3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶h8xRe5 7B/2PN4/PPkPB3/K3r3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶h8xBe5 7B/2PN4/PPkPB3/K3b3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶h8xNe5 7B/2PN4/PPkPB3/K3n3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f4xPe5 8/2PN4/PPkPB3/K3p3/NPP2B2/2RP4/1P2R3/8 w - - ? 1                        
+↶f4xQe5 8/2PN4/PPkPB3/K3q3/NPP2B2/2RP4/1P2R3/8 w - - ? 1                        
+↶f4xRe5 8/2PN4/PPkPB3/K3r3/NPP2B2/2RP4/1P2R3/8 w - - ? 1                        
+↶f4xBe5 8/2PN4/PPkPB3/K3b3/NPP2B2/2RP4/1P2R3/8 w - - ? 1                        
+↶f4xNe5 8/2PN4/PPkPB3/K3n3/NPP2B2/2RP4/1P2R3/8 w - - ? 1                        
+↶g3xPe5 8/2PN4/PPkPB3/K3p3/NPP5/2RP2B1/1P2R3/8 w - - ? 1                        
+↶g3xQe5 8/2PN4/PPkPB3/K3q3/NPP5/2RP2B1/1P2R3/8 w - - ? 1                        
+↶g3xRe5 8/2PN4/PPkPB3/K3r3/NPP5/2RP2B1/1P2R3/8 w - - ? 1                        
+↶g3xBe5 8/2PN4/PPkPB3/K3b3/NPP5/2RP2B1/1P2R3/8 w - - ? 1                        
+↶g3xNe5 8/2PN4/PPkPB3/K3n3/NPP5/2RP2B1/1P2R3/8 w - - ? 1                        
+↶h2xPe5 8/2PN4/PPkPB3/K3p3/NPP5/2RP4/1P2R2B/8 w - - ? 1                         
+↶h2xQe5 8/2PN4/PPkPB3/K3q3/NPP5/2RP4/1P2R2B/8 w - - ? 1                         
+↶h2xRe5 8/2PN4/PPkPB3/K3r3/NPP5/2RP4/1P2R2B/8 w - - ? 1                         
+↶h2xBe5 8/2PN4/PPkPB3/K3b3/NPP5/2RP4/1P2R2B/8 w - - ? 1                         
+↶h2xNe5 8/2PN4/PPkPB3/K3n3/NPP5/2RP4/1P2R2B/8 w - - ? 1                         
+↶d4xPe5 8/2PN4/PPkPB3/K3p3/NPPB4/2RP4/1P2R3/8 w - - ? 1                         
+↶d4xQe5 8/2PN4/PPkPB3/K3q3/NPPB4/2RP4/1P2R3/8 w - - ? 1                         
+↶d4xRe5 8/2PN4/PPkPB3/K3r3/NPPB4/2RP4/1P2R3/8 w - - ? 1                         
+↶d4xBe5 8/2PN4/PPkPB3/K3b3/NPPB4/2RP4/1P2R3/8 w - - ? 1                         
+↶d4xNe5 8/2PN4/PPkPB3/K3n3/NPPB4/2RP4/1P2R3/8 w - - ? 1                         
+↶c5xPb6 dead 8/2PN4/PpkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                   
+↶c5xQb6 dead 8/2PN4/PqkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                   
+↶c5xRb6 8/2PN4/PrkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xBb6 dead 8/2PN4/PbkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                   
+↶c5xNb6 8/2PN4/PnkPB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5b6ep 8/2PN4/P1kPB3/KpP1B3/NPP5/2RP4/1P2R3/8 w - b6 0 1                       
+↶c5xPd6 8/2PN4/PPkpB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xQd6 8/2PN4/PPkqB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xRd6 8/2PN4/PPkrB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xBd6 8/2PN4/PPkbB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xNd6 8/2PN4/PPknB3/K1P1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f7e6 8/2PN1B2/PPkP4/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                           
+↶g8e6 6B1/2PN4/PPkP4/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                           
+↶f5e6 8/2PN4/PPkP4/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1                            
+↶g4e6 8/2PN4/PPkP4/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1                           
+↶h3e6 8/2PN4/PPkP4/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1                            
+↶f7xPe6 8/2PN1B2/PPkPp3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f7xQe6 8/2PN1B2/PPkPq3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f7xRe6 8/2PN1B2/PPkPr3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f7xBe6 8/2PN1B2/PPkPb3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f7xNe6 8/2PN1B2/PPkPn3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g8xPe6 6B1/2PN4/PPkPp3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g8xQe6 6B1/2PN4/PPkPq3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g8xRe6 6B1/2PN4/PPkPr3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g8xBe6 6B1/2PN4/PPkPb3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶g8xNe6 6B1/2PN4/PPkPn3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f5xPe6 8/2PN4/PPkPp3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f5xQe6 8/2PN4/PPkPq3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f5xRe6 8/2PN4/PPkPr3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f5xBe6 8/2PN4/PPkPb3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f5xNe6 8/2PN4/PPkPn3/K3BB2/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶g4xPe6 8/2PN4/PPkPp3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1                        
+↶g4xQe6 8/2PN4/PPkPq3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1                        
+↶g4xRe6 8/2PN4/PPkPr3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1                        
+↶g4xBe6 8/2PN4/PPkPb3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1                        
+↶g4xNe6 8/2PN4/PPkPn3/K3B3/NPP3B1/2RP4/1P2R3/8 w - - ? 1                        
+↶h3xPe6 8/2PN4/PPkPp3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1                         
+↶h3xQe6 8/2PN4/PPkPq3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1                         
+↶h3xRe6 8/2PN4/PPkPr3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1                         
+↶h3xBe6 8/2PN4/PPkPb3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1                         
+↶h3xNe6 8/2PN4/PPkPn3/K3B3/NPP5/2RP3B/1P2R3/8 w - - ? 1                         
+↶f8d7 5N2/2P5/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                           
+↶f6d7 8/2P5/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                            
+↶c5d7 illegal 8/2P5/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                   
+↶f8xPd7 5N2/2Pp4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f8xQd7 5N2/2Pq4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f8xRd7 5N2/2Pr4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f8xBd7 5N2/2Pb4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f8xNd7 5N2/2Pn4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶f6xPd7 8/2Pp4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xQd7 8/2Pq4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xRd7 8/2Pr4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xBd7 8/2Pb4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶f6xNd7 8/2Pn4/PPkPBN2/K3B3/NPP5/2RP4/1P2R3/8 w - - ? 1                         
+↶c5xPd7 illegal 8/2Pp4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                
+↶c5xQd7 8/2Pq4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xRd7 8/2Pr4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xBd7 8/2Pb4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+↶c5xNd7 8/2Pn4/PPkPB3/K1N1B3/NPP5/2RP4/1P2R3/8 w - - ? 1                        
+nsols 188
+                                                                       
 // 43 - P1411205 Per Olin & Joachim Hambros GG052 The Hopper Magazine I04 13/07/2023 2 solutions
 // 44 - P1411234 Andrew Buchanan GG004 Discord Chess Problems & Studies Server 24/09/2022
->>> 8/6Pk/8/6K1/8/8/2p5/8 b >>= hdp1.0
-c2c1n g7g8q DP                                                                  
-nsols 1                                                                        
+>>> 8/6Pk/8/6K1/8/8/2p5/8 b >>= hdp1.0 >>= legal
+c2c1n g7g8q DP (h7g8 insufficient material) 6Q1/7k/8/6K1/8/8/8/2n5 b - - 0 2    
+nsols 1
+                                                                       

--- a/test/PDB.txt
+++ b/test/PDB.txt
@@ -3,86 +3,86 @@
 // 3 long cooked ones are commented out: 31, 32, 33
 
 // 1 - P0002478 Mrs. W. J. Baird 1 British Chess Magazine, p. 491, 12/1903
-8/8/3r4/4N3/4k3/8/8/K7 b >>= r >>= r >>= h#1  // Slow
+8/8/3r4/4N3/4k3/8/8/K7 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 2 - P0002479 Frederick Baird 1877 Morning Post 21/02/1910
-8/8/8/5K2/8/8/7k/8 b >>= r >>= r >>= h#1  // Slow
+8/8/8/5K2/8/8/7k/8 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 3 - P0005387 Nikita M. Plaksin 6557 feenschach 109 11/1993
-8/8/8/8/K7/8/b7/kB6 b >>= r >>= h=0.5
+8/8/8/8/K7/8/b7/kB6 b >>= r >>= h=0.5 >>= legal
 
 // 4 - P1001034 Andrew Buchanan 1 Retros mailing list 24/01/2001
-k7/8/2K5/8/8/8/8/8 ? >>= turn
-k7/8/2K5/8/8/8/8/8 ? >>= r
+k7/8/2K5/8/8/8/8/8 ? >>= legal >>= turn
+k7/8/2K5/8/8/8/8/8 ? >>= r >>= legal
 
 // 5 - P1001036 Andrew Buchanan 2 Retros mailing list 24/01/2001
-k7/N7/2K5/8/8/8/8/8 ? >>= turn
-k7/N7/2K5/8/8/8/8/8 ? >>= r
+k7/N7/2K5/8/8/8/8/8 ? >>= legal >>= turn
+k7/N7/2K5/8/8/8/8/8 ? >>= r >>= legal
 
 // 6 - P1001037 Andrew Buchanan 3 Retros mailing list 24/01/2001
-kB6/2K5/8/2N5/8/8/8/8 ? >>= turn
-kB6/2K5/8/2N5/8/8/8/8 ? >>= r
+kB6/2K5/8/2N5/8/8/8/8 ? >>= legal >>= turn
+kB6/2K5/8/2N5/8/8/8/8 ? >>= r >>= legal
 
 // 7 - P1001038 Andrew Buchanan 4v Retros mailing list 21/01/2001
-8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= castling
-8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= r
-8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= #2
+8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= r >>= legal
+8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w >>= legal >>= castling
+8/7Q/8/4BB2/2PP1P2/3NkN2/PP2P1P1/4K2R w K >>= #2 >>= legal
 
 // 8 - P1001041 Andrew Buchanan 7 Retros mailing list 24/01/2001
-k7/P7/B1K5/8/8/8/8/8 w >>= r
+k7/P7/B1K5/8/8/8/8/8 w >>= r >>= legal
 
 // 9 - P1003981 Andrew Buchanan R0093 StrateGems 18 04-06/2002
-Bb1k1b2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 w >>= r
+Bb1k1b2/bKp1p1p1/1pP1P1P1/1P6/p5P1/P7/8/8 w >>= r >>= legal
 
 // 10 - P1004031 Andrew Buchanan R0089 StrateGems 16 10-12/2001
-1Nk3K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 w >>= r
+1Nk3K1/P1PN1B2/RBP1P3/2P1R1PQ/8/8/8/8 w >>= r >>= legal
 
 // 11 - P1112386 Mrs. W. J. Baird (2) British Chess Magazine, p. 136, 03/1903
-6k1/8/6K1/8/8/8/8/8 b >>= r >>= flip >>= m >>= m >>= flip >>= r >>= flip >>= #1 (p)  // Slow
+6k1/8/6K1/8/8/8/8/8 b >>= r >>= flip >>= m >>= m >>= flip >>= r >>= flip >>= #1 (p) >>= legal  // Slow
 
 // 12 - P1123642 Mrs. W. J. Baird Revue d'Echecs 1903?
-8/8/8/pN1k4/3p1PB1/1K6/8/8 b >>= r >>= h#1.5
+8/8/8/pN1k4/3p1PB1/1K6/8/8 b >>= r >>= h#1.5 >>= legal
 
 // 13 - P1183694 Mrs. W. J. Baird 2 British Chess Magazine, p. 491, 12/1903 (2 solutions)
-6n1/5pb1/7p/rp1k4/1P1N1p2/4q3/8/3K4 b >>= r >>= r >>= h#1  // Slow
+6n1/5pb1/7p/rp1k4/1P1N1p2/4q3/8/3K4 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 14 - P1183695 Mrs. W. J. Baird 3 British Chess Magazine, p. 492, 12/1903 (3 solutions)
-8/3b2p1/2p1p3/6Pp/p2kN2K/3p4/5n2/2r5 b >>= r >>= r >>= h#1  // Slow
+8/3b2p1/2p1p3/6Pp/p2kN2K/3p4/5n2/2r5 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 15 - P1183698 Mrs. W. J. Baird London Field
-1K6/2R1p3/r1P5/1N6/1Nk5/P1nnP3/3P4/2b5 b >>= r >>= h#1.5
+1K6/2R1p3/r1P5/1N6/1Nk5/P1nnP3/3P4/2b5 b >>= r >>= h#1.5 >>= legal
 
 // 16 - P1183934 Mrs. W. J. Baird Cheltenham Examiner
-8/1p6/1K6/2nNk3/8/8/5n2/8 b >>= r >>= r >>= h#1  // Slow
+8/1p6/1K6/2nNk3/8/8/5n2/8 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 17 - P1183936 Mrs. W. J. Baird Leader (Jamaika)
-3k4/8/8/1N3P2/3B4/8/3K4/8 b >>= r >>= h#1.5
+3k4/8/8/1N3P2/3B4/8/3K4/8 b >>= r >>= h#1.5 >>= legal
 
 // 18 - P1183995 Mrs. W. J. Baird 3 Leisure Hour, p. 527, 1904
-8/2K1p3/1n2N3/3kN3/1P3P2/8/8/8 b >>= r >>= h#1.5
+8/2K1p3/1n2N3/3kN3/1P3P2/8/8/8 b >>= r >>= h#1.5 >>= legal
 
 // 19 - P1184001 Mrs. W. J. Baird 144 The Times 17/06/1904
-8/8/2p5/8/1pK5/8/RP2k3/1bn1r3 b >>= r >>= r >>= h#1  // Slow
+8/8/2p5/8/1pK5/8/RP2k3/1bn1r3 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 20 - P1184464 Mrs. W. J. Baird Leisure Hour 1906
-r5b1/1N6/4p3/n1bk1p1p/2n3B1/5p2/K7/7r b >>= r >>= r >>= h#1  // Slow
+r5b1/1N6/4p3/n1bk1p1p/2n3B1/5p2/K7/7r b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 21 - P1185570 Mrs. W. J. Baird Reading Observer
-8/1K6/3bk3/1p3q2/1P6/4P3/8/6B1 b >>= r >>= r >>= h#1  // Slow
+8/1K6/3bk3/1p3q2/1P6/4P3/8/6B1 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 22 - P1414378 Mrs. W. J. Baird & Miguel Ambrona & Andrew Buchanan (Correction of P1185584)
-8/8/4N1p1/1P1k4/8/2K5/8/8 b >>= r >>= r >>= h#1  // Slow
+8/8/4N1p1/1P1k4/8/2K5/8/8 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 23 - P1185751 Mrs. W. J. Baird Bolton Cricket and Football Field
-3K4/4pN2/8/2p5/3k4/2p1R3/8/8 b >>= r >>= h#1.5
+3K4/4pN2/8/2p5/3k4/2p1R3/8/8 b >>= r >>= h#1.5 >>= legal
 
 // 24 - P1187856 Mrs. W. J. Baird Morning Post
-1R6/1bNB2n1/pk2P3/pN2p2p/3pP2K/3P3p/5B1P/6n1 b >>= r >>= #2
+1R6/1bNB2n1/pk2P3/pN2p2p/3pP2K/3P3p/5B1P/6n1 b >>= r >>= #2 >>= legal
 
 // 25 - P1244258 Andrew Buchanan Retros mailing list 01/2001
-8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= castling
-8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= r
-8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= #2
+8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= r >>= legal
+8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= legal >>= castling
+8/8/2Q1N3/3B4/2PP4/3Nk2P/2P5/B2RK2R w >>= #2 >>= legal
 
 // 26 - P1284834 Andrew Buchanan & Joaquim Crusats 3 Problemas 5, p. 107, 1/2014
 qqbqBqN1/brrnq1qq/Rnk1KRN1/3N1N2/1PP5/8/1Q3q2/B4q2 w >>= DP
@@ -91,60 +91,60 @@ qqbqBqN1/brrnq1qq/Rnk1KRN1/3N1N2/1PP5/8/1Q3q2/B4q2 w >>= DP
 qqb1B3/qqrn4/qqkqR3/brnqPKP1/1p2BNN1/1P3P2/8/2R5 b >>= DP
 
 // 28 - P1298521 Mrs. W. J. Baird British Chess Magazine 1906
-5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p3p1/8 b >>= r >>= h#1.5
-5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p1p3/8 b >>= r >>= h#1.5
+5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p3p1/8 b >>= r >>= h#1.5 >>= legal
+5n2/b7/8/1RBPkp2/3p4/1R3bP1/K1p1p3/8 b >>= r >>= h#1.5 >>= legal
 
 // 29 - P1300674 Per Olin 1 Problemas 10, p. 241, 04/2015
-b4b2/1P1PP3/8/k7/6K1/8/6PP/8 w >>= hdp3.5  // Slow
-b4b2/1P2P3/3P4/k7/6K1/8/6PP/8 w >>= hdp3.5  // Slow
+b4b2/1P1PP3/8/k7/6K1/8/6PP/8 w >>= hdp3.5 >>= legal  // Slow
+b4b2/1P2P3/3P4/k7/6K1/8/6PP/8 w >>= hdp3.5 >>= legal  // Slow
 
 // 30 - P1300675 Andrew Buchanan 2 Problemas 10, p. 241, 04/2015
-k7/8/8/N7/8/5KN1/6P1/8 b >>= hdp6.0  // Slow
+k7/8/8/N7/8/5KN1/6P1/8 b >>= hdp6.0 >>= legal  // Slow
 
 // 31 - P1300677 Per Olin 4v Problemas 10, p. 241, 04/2015
-// 3K4/p7/b1p1p1p1/k1P1P1P1/P7/P5P1/5P2/8 w >>= hdp8.5  // Slow and COOKED
+// 3K4/p7/b1p1p1p1/k1P1P1P1/P7/P5P1/5P2/8 w >>= hdp8.5 >>= legal  // Slow and COOKED
 
 // 32 - P1305687 Per Olin Mat Plus 09/04/2015
-// 1b6/2k1P3/4P3/1K6/8/8/2p2pP1/8 b >>= hdp5.0  // Slow and COOKED
+// 1b6/2k1P3/4P3/1K6/8/8/2p2pP1/8 b >>= hdp5.0 >>= legal  // Slow and COOKED
 
 // 33 - P1324767 Andrey Frolkin & Per Olin 3v1 Problemas 13, p. 331, 1/2016
-// 4b2K/3rk1PP/3pppp1/2p5/p1p5/P7/PnPP4/RRB5 b >>= hdp 5.0  // Slow and COOKED
-// 4b2K/3rkP1P/3pppp1/2p5/p1p5/P7/PnPP4/RRB5 b >>= hdp 5.0  // Slow and COOKED
+// 4b2K/3rk1PP/3pppp1/2p5/p1p5/P7/PnPP4/RRB5 b >>= hdp 5.0 >>= legal  // Slow and COOKED
+// 4b2K/3rkP1P/3pppp1/2p5/p1p5/P7/PnPP4/RRB5 b >>= hdp 5.0 >>= legal  // Slow and COOKED
 
 // 34 - P1324768 Per Olin 5v Problemas 13, p. 331, 1/2016
-8/2p4P/2R5/3B4/8/8/2P5/KNk5 b >>= hdp4.0  // Slow
+8/2p4P/2R5/3B4/8/8/2P5/KNk5 b >>= hdp4.0 >>= legal  // Slow
 
 // 35 - P1324769 Andrey Frolkin & Per Olin 3v2 Problemas 13, p. 331, 1/2016
-2brnn1K/1ppprkPP/3pppp1/1p6/8/8/P3P1P1/5B2 w >>= hdp4.5  // Slow
-2br1n1K/1ppprkPP/3pppp1/1p6/8/8/P3P1P1/5B2 w >>= hdp4.5  // Slow
+2brnn1K/1ppprkPP/3pppp1/1p6/8/8/P3P1P1/5B2 w >>= hdp4.5 >>= legal  // Slow
+2br1n1K/1ppprkPP/3pppp1/1p6/8/8/P3P1P1/5B2 w >>= hdp4.5 >>= legal  // Slow
 
 // 36 - P1338362 Andrew Buchanan 2 Problemas 18, p. 487, 04/2017
-8/5p2/5P2/8/1p6/kP2pp2/1pKpP3/3B4 w >>= r >>= h=1
+8/5p2/5P2/8/1p6/kP2pp2/1pKpP3/3B4 w >>= r >>= h=1 >>= legal
 
 // 37 - P1345823 Andrew Buchanan 6 Problemas 20, p. 553, 10/2017 Article 15
 8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 ? >>= legal
-8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 w >>= h=1.5
+8/p7/8/P2p4/Pp1p4/kP1Pp3/p1KpP3/NQ1B4 w >>= h=1.5 >>= legal
 
 // 38 - P1368543 Per Olin & Andrew Buchanan Springaren 149, p. 4, 03/2019
-1rR2RN1/8/8/8/8/8/Kp5b/1N4rk b >>= hdp3.0  // Slow
+1rR2RN1/8/8/8/8/8/Kp5b/1N4rk b >>= hdp3.0 >>= legal  // Slow
 
 // 39 - P1404973 Per Olin Springaren 2021 Commendation Springaren Summer Competition 2021 c cooked & how about D?
-1k6/6B1/4p3/8/8/3b4/3P2K1/8 b >>= hdp3.0  // Slow
-8/7k/8/1Pb5/5p2/8/1K4B1/8 b >>= hdp3.0  // Slow
-8/1K2P3/4b3/8/8/3p4/1B6/6k1 b >>= hdp3.0  // Slow
-8/1B4K1/8/2p5/5bP1/8/k7/8 b >>= hdp3.0  // Slow
+1k6/6B1/4p3/8/8/3b4/3P2K1/8 b >>= hdp3.0 >>= legal  // Slow
+8/7k/8/1Pb5/5p2/8/1K4B1/8 b >>= hdp3.0 >>= legal  // Slow
+8/1K2P3/4b3/8/8/3p4/1B6/6k1 b >>= hdp3.0 >>= legal  // Slow
+8/1B4K1/8/2p5/5bP1/8/k7/8 b >>= hdp3.0 >>= legal  // Slow
 
 // 40 - P1405799 Mrs. W. J. Baird & Andrew Buchanan PDB Website 13/11/2022 WJB, correction AB 4 solutions
-8/b2br3/1pp1p3/6Pn/p2kN2K/3p2P1/5n2/2r5 b >>= r >>= r >>= h#1  // Slow
+8/b2br3/1pp1p3/6Pn/p2kN2K/3p2P1/5n2/2r5 b >>= r >>= r >>= h#1 >>= legal  // Slow
 
 // 41 - P1408993 Andrew Buchanan 24 A Practical Algorithm for Chess Unwinnability 2022
-8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbK5 b >>= r
+8/8/1Pp5/p7/P1p5/PpPp4/brpP4/kbK5 b >>= r >>= legal
 
 // 42 - P1408994 Andrey Frolkin & Andrew Buchanan 25 A Practical Algorithm for Chess Unwinnability 2022
-8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 ? >>= r
+8/2PN4/PPkPB3/K3B3/NPP5/2RP4/1P2R3/8 ? >>= r >>= legal
 
 // 43 - P1411205 Per Olin & Joachim Hambros GG052 The Hopper Magazine I04 13/07/2023 2 solutions
-3k4/p7/8/8/8/8/7P/4K3 b >>= hdp5.0  // Slow
+3k4/p7/8/8/8/8/7P/4K3 b >>= hdp5.0 >>= legal  // Slow
 
 // 44 - P1411234 Andrew Buchanan GG004 Discord Chess Problems & Studies Server 24/09/2022
-8/6Pk/8/6K1/8/8/2p5/8 b >>= hdp1.0
+8/6Pk/8/6K1/8/8/2p5/8 b >>= hdp1.0 >>= legal

--- a/test/test-vectors.out
+++ b/test/test-vectors.out
@@ -1,38 +1,47 @@
-Deadpos Analyzer version 2.2
+Deadpos Analyzer version 2.3
 // Josef Jána, 1928 (Neues Grazer Tagblatt), 1 solution.
->>> r3k3/3N4/2N5/8/1K6/8/7p/8 b q - >>= h#3
-h2h1b c6b8 h1b7 b8a6 e8c8 d7b6#                                                 
-nsols 1                                                                        
+>>> r3k3/3N4/2N5/8/1K6/8/7p/8 b q - >>= h#3 >>= legal
+h2h1b c6b8 h1b7 b8a6 e8c8 d7b6# 2kr4/1b1N4/N7/8/1K6/8/8/8 w - - 4 4             
+nsols 1
+                                                                       
 // Chris Feather, 1975 (Schach), 2 solutions.
->>> 1RrB2b1/8/4n3/2n3p1/2K2b2/1p1rk3/6BR/8 b - - >>= h#2
-f4b8 g2d5 e6c7 d8g5#                                                            
-d3d8 g2c6 c5d7 b8b3#                                                            
-nsols 2                                                                        
+>>> 1RrB2b1/8/4n3/2n3p1/2K2b2/1p1rk3/6BR/8 b - - >>= h#2 >>= legal
+f4b8 g2d5 e6c7 d8g5# 1brB2b1/2n5/8/2nB2p1/2K5/1p1rk3/7R/8 w - - 2 3             
+d3d8 g2c6 c5d7 b8b3# 1Rrr2b1/3n4/2B1n3/6p1/2K2b2/1p2k3/7R/8 w - - 2 3           
+nsols 2
+                                                                       
 // Milan Vukcevich, 1996 (CHM avec 6 pieces Bad Pyrmont), 1 solution.
->>> 4K2n/3P1P2/4k3/3p4/8/8/8/8 b - - >>= h#2
-h8g6 f7f8q g6e5 d7d8n#                                                          
-nsols 1                                                                        
+>>> 4K2n/3P1P2/4k3/3p4/8/8/8/8 b - - >>= h#2 >>= legal
+h8g6 f7f8q g6e5 d7d8n# 4KQ2/3P4/4k3/3pn3/8/8/8/8 w - - 1 3                      
+nsols 1
+                                                                       
 // Roddy McKay, 2021 (Matplus.net), 1 solution.
->>> 8/1B6/3p1P1q/4ppB1/1p3b2/1Pk3p1/2P4p/1K6 b - - >>= h#2
-f4c1 g5c1 h6d2 c1b2#                                                            
-nsols 1                                                                        
+>>> 8/1B6/3p1P1q/4ppB1/1p3b2/1Pk3p1/2P4p/1K6 b - - >>= h#2 >>= legal
+f4c1 g5c1 h6d2 c1b2# 8/1B6/3p1P2/4pp2/1p6/1Pk3p1/2Pq3p/1KB5 w - - 1 3           
+nsols 1
+                                                                       
 // Neal Turner, 1995 (Problemist Supplement), 1 solution.
->>> q1b1n1K1/2P1P3/8/3k4/8/8/8/8 b - - >>= h#3
-c8f5 c7c8r d5e6 c8e8 a8d8 e7d8q#                                                
-nsols 1                                                                        
+>>> q1b1n1K1/2P1P3/8/3k4/8/8/8/8 b - - >>= h#3 >>= legal
+c8f5 c7c8r d5e6 c8e8 a8d8 e7d8q# 3qR1K1/4P3/4k3/5b2/8/8/8/8 w - - 1 4           
+nsols 1
+                                                                       
 // Miguel Ambrona, 2021 (Matplus.net), 1 solution.
->>> 8/4K2k/4P2p/8/5q2/2b5/8/8 b - - >>= h#3
-f4b8 e7f7 c3h8 e6e7 b8f8 e7f8n#                                                 
-nsols 1                                                                        
->>> 8/8/2B5/5Q2/8/4p2P/4k2K/8 w - - >>= h#3 half-duplex
-f5b1 e2f2 c6h1 e3e2 b1f1 e2f1n#                                                 
-nsols 1                                                                        
+>>> 8/4K2k/4P2p/8/5q2/2b5/8/8 b - - >>= h#3 >>= legal
+f4b8 e7f7 c3h8 e6e7 b8f8 e7f8n# 5q1b/4PK1k/7p/8/8/8/8/8 w - - 1 4               
+nsols 1
+                                                                       
+>>> 8/8/2B5/5Q2/8/4p2P/4k2K/8 w - - >>= h#3 half-duplex >>= legal
+f5b1 e2f2 c6h1 e3e2 b1f1 e2f1n# 8/8/8/8/8/7P/4pk1K/5Q1B b - - 1 3               
+nsols 1
+                                                                       
 // Test en-passant
->>> 4k2r/8/2P1P1P1/2PpKpP1/8/8/8/8 w k ? >>= ep
+>>> 4k2r/8/2P1P1P1/2PpKpP1/8/8/8/8 w k ? >>= legal >>= ep
 d6
 f6
-nsols 2                                                                        
+nsols 2
+                                                                       
 // Test castling
->>> 4k2r/8/8/8/8/8/8/4K3 w >>= castling
+>>> 4k2r/8/8/8/8/8/8/4K3 w >>= legal >>= castling
 -
-nsols 1                                                                        
+nsols 1
+                                                                       

--- a/test/test-vectors.txt
+++ b/test/test-vectors.txt
@@ -1,24 +1,24 @@
 // Josef Jána, 1928 (Neues Grazer Tagblatt), 1 solution.
-r3k3/3N4/2N5/8/1K6/8/7p/8 b q - >>= h#3
+r3k3/3N4/2N5/8/1K6/8/7p/8 b q - >>= h#3 >>= legal
 
 // Chris Feather, 1975 (Schach), 2 solutions.
-1RrB2b1/8/4n3/2n3p1/2K2b2/1p1rk3/6BR/8 b - - >>= h#2
+1RrB2b1/8/4n3/2n3p1/2K2b2/1p1rk3/6BR/8 b - - >>= h#2 >>= legal
 
 // Milan Vukcevich, 1996 (CHM avec 6 pieces Bad Pyrmont), 1 solution.
-4K2n/3P1P2/4k3/3p4/8/8/8/8 b - - >>= h#2
+4K2n/3P1P2/4k3/3p4/8/8/8/8 b - - >>= h#2 >>= legal
 
 // Roddy McKay, 2021 (Matplus.net), 1 solution.
-8/1B6/3p1P1q/4ppB1/1p3b2/1Pk3p1/2P4p/1K6 b - - >>= h#2
+8/1B6/3p1P1q/4ppB1/1p3b2/1Pk3p1/2P4p/1K6 b - - >>= h#2 >>= legal
 
 // Neal Turner, 1995 (Problemist Supplement), 1 solution.
-q1b1n1K1/2P1P3/8/3k4/8/8/8/8 b - - >>= h#3
+q1b1n1K1/2P1P3/8/3k4/8/8/8/8 b - - >>= h#3 >>= legal
 
 // Miguel Ambrona, 2021 (Matplus.net), 1 solution.
-8/4K2k/4P2p/8/5q2/2b5/8/8 b - - >>= h#3
-8/8/2B5/5Q2/8/4p2P/4k2K/8 w - - >>= h#3 half-duplex
+8/4K2k/4P2p/8/5q2/2b5/8/8 b - - >>= h#3 >>= legal
+8/8/2B5/5Q2/8/4p2P/4k2K/8 w - - >>= h#3 half-duplex >>= legal
 
 // Test en-passant
-4k2r/8/2P1P1P1/2PpKpP1/8/8/8/8 w k ? >>= ep
+4k2r/8/2P1P1P1/2PpKpP1/8/8/8/8 w k ? >>= legal >>= ep
 
 // Test castling
-4k2r/8/8/8/8/8/8/4K3 w >>= castling
+4k2r/8/8/8/8/8/8/4K3 w >>= legal >>= castling


### PR DESCRIPTION
Including the following changes:

 - Introduce `legal`, a command that must be called in order to perform legal and dead/alive analysis on positions. If this is not used, we will work with all positions even if they are illegal.
 
 - Introduce the term "zombie". We now have three classes of positions:
    - _illegal_: same as FIDE (no game following the rules can reach the position).
    - _zombie_: legal, but all possible restractions are dead.
    -  legal and not zombie (a reachable position following the mobility rules + DP).

- Introduce a small symbol ↶ next to retractions to differentiate them from forward moves.

- Introduce explanations for dead and living positions when relevant.

- Forward solve commands now return the final position (thus they keep the monadic chain going).

- FENs are now printed after and not before the (potential) variation.

- Introduce colors to make the output parsing easier (for humans).

- Remove the `--verbose` flag.